### PR TITLE
L10: Add restricted ZFS FS sub-plugin

### DIFF
--- a/docs/libblockdev-sections.txt
+++ b/docs/libblockdev-sections.txt
@@ -720,6 +720,12 @@ bd_fs_udf_set_label
 bd_fs_udf_check_label
 bd_fs_udf_set_uuid
 bd_fs_udf_check_uuid
+BDFSZfsInfo
+bd_fs_zfs_get_info
+bd_fs_zfs_info_copy
+bd_fs_zfs_info_free
+bd_fs_zfs_check_label
+bd_fs_zfs_check_uuid
 </SECTION>
 
 <SECTION>

--- a/src/lib/plugin_apis/fs.api
+++ b/src/lib/plugin_apis/fs.api
@@ -2634,6 +2634,103 @@ gboolean bd_fs_udf_check_uuid (const gchar *uuid, GError **error);
  */
 BDFSUdfInfo* bd_fs_udf_get_info (const gchar *device, GError **error);
 
+/**
+ * BDFSZfsInfo:
+ * @label: label (pool name) of the ZFS filesystem
+ * @uuid: uuid (pool GUID) of the ZFS filesystem
+ * @size: size of the ZFS pool in bytes
+ * @free_space: free space in the ZFS pool in bytes
+ */
+typedef struct BDFSZfsInfo {
+    gchar *label;
+    gchar *uuid;
+    guint64 size;
+    guint64 free_space;
+} BDFSZfsInfo;
+
+/**
+ * bd_fs_zfs_info_free: (skip)
+ * @data: (nullable): %BDFSZfsInfo to free
+ *
+ * Frees @data.
+ */
+void bd_fs_zfs_info_free (BDFSZfsInfo *data) {
+    if (data == NULL)
+        return;
+
+    g_free (data->label);
+    g_free (data->uuid);
+    g_free (data);
+}
+
+/**
+ * bd_fs_zfs_info_copy: (skip)
+ * @data: (nullable): %BDFSZfsInfo to copy
+ *
+ * Creates a new copy of @data.
+ */
+BDFSZfsInfo* bd_fs_zfs_info_copy (BDFSZfsInfo *data) {
+    if (data == NULL)
+        return NULL;
+
+    BDFSZfsInfo *ret = g_new0 (BDFSZfsInfo, 1);
+
+    ret->label = g_strdup (data->label);
+    ret->uuid = g_strdup (data->uuid);
+    ret->size = data->size;
+    ret->free_space = data->free_space;
+
+    return ret;
+}
+
+GType bd_fs_zfs_info_get_type () {
+    static GType type = 0;
+
+    if (G_UNLIKELY(type == 0)) {
+        type = g_boxed_type_register_static("BDFSZfsInfo",
+                                            (GBoxedCopyFunc) bd_fs_zfs_info_copy,
+                                            (GBoxedFreeFunc) bd_fs_zfs_info_free);
+    }
+
+    return type;
+}
+
+/**
+ * bd_fs_zfs_check_label:
+ * @label: label to check
+ * @error: (out) (optional): place to store error
+ *
+ * Returns: whether @label is a valid label for a ZFS pool or not
+ *          (reason is provided in @error)
+ *
+ * Tech category: always available
+ */
+gboolean bd_fs_zfs_check_label (const gchar *label, GError **error);
+
+/**
+ * bd_fs_zfs_check_uuid:
+ * @uuid: UUID to check
+ * @error: (out) (optional): place to store error
+ *
+ * Returns: whether @uuid is a valid UUID (pool GUID) for ZFS or not
+ *          (reason is provided in @error)
+ *
+ * Tech category: always available
+ */
+gboolean bd_fs_zfs_check_uuid (const gchar *uuid, GError **error);
+
+/**
+ * bd_fs_zfs_get_info:
+ * @device: the device containing the file system to get info for
+ * @error: (out) (optional): place to store error (if any)
+ *
+ * Returns: (transfer full): information about the ZFS file system on @device or
+ *                           %NULL in case of error
+ *
+ * Tech category: %BD_FS_TECH_ZFS-%BD_FS_TECH_MODE_QUERY
+ */
+BDFSZfsInfo* bd_fs_zfs_get_info (const gchar *device, GError **error);
+
 typedef enum {
     BD_FS_SUPPORT_SET_LABEL = 1 << 1,
     BD_FS_SUPPORT_SET_UUID = 1 << 2

--- a/src/plugins/fs.c
+++ b/src/plugins/fs.c
@@ -41,6 +41,7 @@ extern gboolean bd_fs_nilfs2_is_tech_avail (BDFSTech tech, guint64 mode, GError 
 extern gboolean bd_fs_exfat_is_tech_avail (BDFSTech tech, guint64 mode, GError **error);
 extern gboolean bd_fs_btrfs_is_tech_avail (BDFSTech tech, guint64 mode, GError **error);
 extern gboolean bd_fs_udf_is_tech_avail (BDFSTech tech, guint64 mode, GError **error);
+extern gboolean bd_fs_zfs_is_tech_avail (BDFSTech tech, guint64 mode, GError **error);
 
 /**
  * bd_fs_error_quark: (skip)
@@ -116,6 +117,8 @@ gboolean bd_fs_is_tech_avail (BDFSTech tech, guint64 mode, GError **error) {
             return bd_fs_btrfs_is_tech_avail (tech, mode, error);
         case BD_FS_TECH_UDF:
             return bd_fs_udf_is_tech_avail (tech, mode, error);
+        case BD_FS_TECH_ZFS:
+            return bd_fs_zfs_is_tech_avail (tech, mode, error);
         /* coverity[dead_error_begin] */
         default:
             /* this should never be reached (see the comparison with LAST_FS

--- a/src/plugins/fs.h
+++ b/src/plugins/fs.h
@@ -23,7 +23,7 @@ typedef enum {
 
 /* XXX: where the file systems start at the enum of technologies */
 #define BD_FS_OFFSET 2
-#define BD_FS_LAST_FS 13
+#define BD_FS_LAST_FS 14
 typedef enum {
     BD_FS_TECH_GENERIC  = 0,
     BD_FS_TECH_MOUNT    = 1,
@@ -38,6 +38,7 @@ typedef enum {
     BD_FS_TECH_EXFAT    = 10,
     BD_FS_TECH_BTRFS    = 11,
     BD_FS_TECH_UDF      = 12,
+    BD_FS_TECH_ZFS      = 13,
 } BDFSTech;
 
 /* XXX: number of the highest bit of all modes */
@@ -80,3 +81,4 @@ gboolean bd_fs_is_tech_avail (BDFSTech tech, guint64 mode, GError **error);
 #include "fs/exfat.h"
 #include "fs/btrfs.h"
 #include "fs/udf.h"
+#include "fs/zfs.h"

--- a/src/plugins/fs/Makefile.am
+++ b/src/plugins/fs/Makefile.am
@@ -19,7 +19,8 @@ libbd_fs_la_SOURCES  = ../check_deps.c ../check_deps.h \
 						nilfs.c    nilfs.h    \
 						exfat.c    exfat.h    \
 						btrfs.c    btrfs.h    \
-						udf.c      udf.h
+						udf.c      udf.h      \
+						zfs.c      zfs.h
 
 libincludefsdir = $(includedir)/blockdev/fs/
 libincludefs_HEADERS = ext.h     \
@@ -32,4 +33,5 @@ libincludefs_HEADERS = ext.h     \
 					nilfs.h    \
 					exfat.h    \
 					btrfs.h    \
-					udf.h
+					udf.h      \
+					zfs.h

--- a/src/plugins/fs/generic.c
+++ b/src/plugins/fs/generic.c
@@ -174,6 +174,8 @@ static const BDFSFeatures fs_features[BD_FS_LAST_FS] = {
       .partition_type = "ebd0a0a2-b9e5-4433-87c0-68b6b72699c7",
       .min_size = 2 MiB,
       .max_size = 16 TiB },
+    /* ZFS -- restricted: no operations through generic FS dispatch */
+    { 0 },
 };
 
 /**
@@ -312,6 +314,16 @@ const BDFSInfo fs_info[BD_FS_LAST_FS] = {
       .label_util = "udflabel",
       .info_util = "udfinfo",
       .uuid_util = "udflabel" },
+    /* ZFS -- restricted: only query via top-level ZFS plugin */
+    { .type = "zfs",
+      .mkfs_util = NULL,
+      .check_util = NULL,
+      .repair_util = NULL,
+      .resize_util = NULL,
+      .minsize_util = NULL,
+      .label_util = NULL,
+      .info_util = "zpool",
+      .uuid_util = NULL },
 };
 
 /**
@@ -366,6 +378,8 @@ static BDFSTech fstype_to_tech (const gchar *fstype) {
         return BD_FS_TECH_BTRFS;
     } else if (g_strcmp0 (fstype, "udf") == 0) {
         return BD_FS_TECH_UDF;
+    } else if (g_strcmp0 (fstype, "zfs") == 0 || g_strcmp0 (fstype, "zfs_member") == 0) {
+        return BD_FS_TECH_ZFS;
     } else {
         return BD_FS_TECH_GENERIC;
     }

--- a/src/plugins/fs/zfs.c
+++ b/src/plugins/fs/zfs.c
@@ -1,0 +1,246 @@
+/*
+ * Copyright (C) 2024  Red Hat, Inc.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, see <http://www.gnu.org/licenses/>.
+ *
+ * Author: Razvan Vilt
+ */
+
+#include <blockdev/utils.h>
+#include <check_deps.h>
+#include <string.h>
+
+#include "zfs.h"
+#include "fs.h"
+#include "common.h"
+
+/* ZFS FS sub-plugin: SEVERELY RESTRICTED per security review.
+ * Only get_info, check_label, and check_uuid are functional.
+ * All other operations (mkfs, check, repair, resize, set_label, set_uuid)
+ * return NOT_SUPPORTED to prevent pool-level operations from being
+ * triggered through the generic FS dispatch path.
+ */
+
+static volatile guint avail_deps = 0;
+static GMutex deps_check_lock;
+
+#define DEPS_ZPOOL 0
+#define DEPS_ZPOOL_MASK (1 << DEPS_ZPOOL)
+#define DEPS_LAST 1
+
+static const UtilDep deps[DEPS_LAST] = {
+    {"zpool", NULL, NULL, NULL},
+};
+
+
+/**
+ * bd_fs_zfs_is_tech_avail:
+ * @tech: the queried tech
+ * @mode: a bit mask of queried modes of operation (#BDFSTechMode) for @tech
+ * @error: (out) (optional): place to store error (details about why the @tech-@mode combination is not available)
+ *
+ * Returns: whether the @tech-@mode combination is available -- supported by the
+ *          plugin implementation and having all the runtime dependencies available
+ */
+G_GNUC_INTERNAL gboolean
+bd_fs_zfs_is_tech_avail (BDFSTech tech G_GNUC_UNUSED, guint64 mode, GError **error) {
+    /* only QUERY mode is supported */
+    if (mode & ~BD_FS_TECH_MODE_QUERY) {
+        g_set_error (error, BD_FS_ERROR, BD_FS_ERROR_TECH_UNAVAIL,
+                     "ZFS FS operations other than query are not supported through the generic FS interface. "
+                     "Use the BD_PLUGIN_ZFS top-level plugin instead.");
+        return FALSE;
+    }
+
+    return check_deps (&avail_deps, DEPS_ZPOOL_MASK, deps, DEPS_LAST, &deps_check_lock, error);
+}
+
+/**
+ * bd_fs_zfs_info_copy: (skip)
+ *
+ * Creates a new copy of @data.
+ */
+BDFSZfsInfo* bd_fs_zfs_info_copy (BDFSZfsInfo *data) {
+    if (data == NULL)
+        return NULL;
+
+    BDFSZfsInfo *ret = g_new0 (BDFSZfsInfo, 1);
+
+    ret->label = g_strdup (data->label);
+    ret->uuid = g_strdup (data->uuid);
+    ret->size = data->size;
+    ret->free_space = data->free_space;
+
+    return ret;
+}
+
+/**
+ * bd_fs_zfs_info_free: (skip)
+ *
+ * Frees @data.
+ */
+void bd_fs_zfs_info_free (BDFSZfsInfo *data) {
+    if (data == NULL)
+        return;
+
+    g_free (data->label);
+    g_free (data->uuid);
+    g_free (data);
+}
+
+/**
+ * bd_fs_zfs_check_label:
+ * @label: label to check
+ * @error: (out) (optional): place to store error
+ *
+ * Returns: whether @label is a valid label for a ZFS pool or not
+ *          (reason is provided in @error)
+ *
+ * Tech category: always available
+ */
+gboolean bd_fs_zfs_check_label (const gchar *label, GError **error) {
+    /* ZFS pool names: 1-255 chars, alphanumeric + _ - . : (no leading digit, no leading -) */
+    if (label == NULL || *label == '\0') {
+        g_set_error (error, BD_FS_ERROR, BD_FS_ERROR_LABEL_INVALID,
+                     "ZFS pool name cannot be empty");
+        return FALSE;
+    }
+
+    if (strlen (label) > 255) {
+        g_set_error (error, BD_FS_ERROR, BD_FS_ERROR_LABEL_INVALID,
+                     "ZFS pool name too long (max 255 characters)");
+        return FALSE;
+    }
+
+    /* Must not start with digit or dash */
+    if (g_ascii_isdigit (label[0]) || label[0] == '-') {
+        g_set_error (error, BD_FS_ERROR, BD_FS_ERROR_LABEL_INVALID,
+                     "ZFS pool name must not start with a digit or dash");
+        return FALSE;
+    }
+
+    /* Only alphanumeric, underscore, dash, period, colon */
+    for (const gchar *p = label; *p; p++) {
+        if (!g_ascii_isalnum (*p) && *p != '_' && *p != '-' && *p != '.' && *p != ':') {
+            g_set_error (error, BD_FS_ERROR, BD_FS_ERROR_LABEL_INVALID,
+                         "ZFS pool name contains invalid character '%c'", *p);
+            return FALSE;
+        }
+    }
+
+    /* Reserved names */
+    if (g_strcmp0 (label, "mirror") == 0 || g_strcmp0 (label, "raidz") == 0 ||
+        g_strcmp0 (label, "draid") == 0 || g_strcmp0 (label, "spare") == 0 ||
+        g_strcmp0 (label, "log") == 0 || g_strcmp0 (label, "cache") == 0 ||
+        g_strcmp0 (label, "special") == 0 || g_strcmp0 (label, "dedup") == 0) {
+        g_set_error (error, BD_FS_ERROR, BD_FS_ERROR_LABEL_INVALID,
+                     "ZFS pool name '%s' is reserved", label);
+        return FALSE;
+    }
+
+    return TRUE;
+}
+
+/**
+ * bd_fs_zfs_check_uuid:
+ * @uuid: UUID to check
+ * @error: (out) (optional): place to store error
+ *
+ * Returns: whether @uuid is a valid UUID (pool GUID) for ZFS or not
+ *          (reason is provided in @error)
+ *
+ * Tech category: always available
+ */
+gboolean bd_fs_zfs_check_uuid (const gchar *uuid, GError **error) {
+    /* ZFS pool GUIDs are 64-bit unsigned integers, not standard UUIDs */
+    if (uuid == NULL || *uuid == '\0') {
+        g_set_error (error, BD_FS_ERROR, BD_FS_ERROR_UUID_INVALID,
+                     "ZFS pool GUID cannot be empty");
+        return FALSE;
+    }
+
+    /* Validate it's a valid uint64 */
+    gchar *end = NULL;
+    g_ascii_strtoull (uuid, &end, 10);
+    if (end == uuid || *end != '\0') {
+        g_set_error (error, BD_FS_ERROR, BD_FS_ERROR_UUID_INVALID,
+                     "ZFS pool GUID must be a decimal number");
+        return FALSE;
+    }
+
+    return TRUE;
+}
+
+/**
+ * bd_fs_zfs_get_info:
+ * @device: the device containing the file system to get info for
+ * @error: (out) (optional): place to store error (if any)
+ *
+ * Returns: (transfer full): information about the ZFS file system on @device or
+ *                           %NULL in case of error
+ *
+ * Tech category: %BD_FS_TECH_ZFS-%BD_FS_TECH_MODE_QUERY
+ */
+BDFSZfsInfo* bd_fs_zfs_get_info (const gchar *device, GError **error) {
+    const gchar *argv[] = {"zpool", "list", "-H", "-p", "-o", "name,guid,size,free", NULL};
+    gchar *output = NULL;
+    gboolean success;
+
+    if (!check_deps (&avail_deps, DEPS_ZPOOL_MASK, deps, DEPS_LAST, &deps_check_lock, error))
+        return NULL;
+
+    success = bd_utils_exec_and_capture_output (argv, NULL, &output, error);
+    if (!success) {
+        g_free (output);
+        return NULL;
+    }
+
+    if (output == NULL || *output == '\0') {
+        g_free (output);
+        g_set_error (error, BD_FS_ERROR, BD_FS_ERROR_FAIL,
+                     "No ZFS pools found");
+        return NULL;
+    }
+
+    /* Parse first line: name\tguid\tsize\tfree */
+    gchar **lines = g_strsplit (output, "\n", 2);
+    g_free (output);
+
+    if (lines[0] == NULL || *lines[0] == '\0') {
+        g_strfreev (lines);
+        g_set_error (error, BD_FS_ERROR, BD_FS_ERROR_FAIL,
+                     "Failed to parse ZFS pool info");
+        return NULL;
+    }
+
+    gchar **fields = g_strsplit (lines[0], "\t", -1);
+    g_strfreev (lines);
+
+    guint n_fields = g_strv_length (fields);
+    if (n_fields < 4) {
+        g_strfreev (fields);
+        g_set_error (error, BD_FS_ERROR, BD_FS_ERROR_FAIL,
+                     "Unexpected zpool list output format");
+        return NULL;
+    }
+
+    BDFSZfsInfo *info = g_new0 (BDFSZfsInfo, 1);
+    info->label = g_strdup (fields[0]);        /* pool name */
+    info->uuid = g_strdup (fields[1]);         /* pool GUID */
+    info->size = g_ascii_strtoull (fields[2], NULL, 10);
+    info->free_space = g_ascii_strtoull (fields[3], NULL, 10);
+
+    g_strfreev (fields);
+    return info;
+}

--- a/src/plugins/fs/zfs.h
+++ b/src/plugins/fs/zfs.h
@@ -1,0 +1,21 @@
+#include <glib.h>
+#include <blockdev/utils.h>
+
+#ifndef BD_FS_ZFS
+#define BD_FS_ZFS
+
+typedef struct BDFSZfsInfo {
+    gchar *label;
+    gchar *uuid;
+    guint64 size;
+    guint64 free_space;
+} BDFSZfsInfo;
+
+BDFSZfsInfo* bd_fs_zfs_info_copy (BDFSZfsInfo *data);
+void bd_fs_zfs_info_free (BDFSZfsInfo *data);
+
+gboolean bd_fs_zfs_check_label (const gchar *label, GError **error);
+gboolean bd_fs_zfs_check_uuid (const gchar *uuid, GError **error);
+BDFSZfsInfo* bd_fs_zfs_get_info (const gchar *device, GError **error);
+
+#endif  /* BD_FS_ZFS */


### PR DESCRIPTION
## Summary
- Add BD_FS_TECH_ZFS to FS plugin with ALL capabilities zero
- Only get_info, check_label, check_uuid are functional
- is_tech_avail rejects all modes except QUERY
- Pool name and GUID validation
- Security: no pool ops through generic FS dispatch

Closes #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)