### PR TITLE
Fix: Add ZFS to spec file + wire FS generic dispatch

### DIFF
--- a/dist/libblockdev.spec.in
+++ b/dist/libblockdev.spec.in
@@ -18,6 +18,7 @@
 %define with_nvme @WITH_NVME@
 %define with_smart @WITH_SMART@
 %define with_smartmontools @WITH_SMARTMONTOOLS@
+%define with_zfs @WITH_ZFS@
 
 # btrfs is not available on RHEL > 7
 %if 0%{?rhel} > 7 || %{with_btrfs} == 0
@@ -27,6 +28,9 @@
 
 %if %{with_btrfs} != 1
 %define btrfs_copts --without-btrfs
+%endif
+%if %{with_zfs} != 1
+%define zfs_copts --without-zfs
 %endif
 %if %{with_crypto} != 1
 %define crypto_copts --without-crypto
@@ -82,7 +86,7 @@
 %define smartmontools_copts --without-smartmontools
 %endif
 
-%define configure_opts %{?python3_copts} %{?lvm_dbus_copts} %{?btrfs_copts} %{?crypto_copts} %{?dm_copts} %{?loop_copts} %{?lvm_copts} %{?lvm_dbus_copts} %{?mdraid_copts} %{?mpath_copts} %{?swap_copts} %{?part_copts} %{?fs_copts} %{?nvdimm_copts} %{?tools_copts} %{?gi_copts} %{?nvme_copts} %{?smart_copts} %{?smartmontools_copts}
+%define configure_opts %{?python3_copts} %{?lvm_dbus_copts} %{?btrfs_copts} %{?crypto_copts} %{?dm_copts} %{?loop_copts} %{?lvm_copts} %{?lvm_dbus_copts} %{?mdraid_copts} %{?mpath_copts} %{?swap_copts} %{?part_copts} %{?fs_copts} %{?nvdimm_copts} %{?tools_copts} %{?gi_copts} %{?nvme_copts} %{?smart_copts} %{?smartmontools_copts} %{?zfs_copts}
 
 Name:        libblockdev
 Version:     3.4.0
@@ -526,6 +530,26 @@ This package contains header files and pkg-config files needed for development
 with the libblockdev-swap plugin/library.
 %endif
 
+%if %{with_zfs}
+%package zfs
+Summary:     The ZFS plugin for the libblockdev library
+Requires: %{name}-utils%{?_isa} = %{version}-%{release}
+
+%description zfs
+The libblockdev library plugin (and in the same time a standalone library)
+providing the ZFS-related functionality.
+
+%package zfs-devel
+Summary:     Development files for the libblockdev-zfs plugin/library
+Requires: %{name}-zfs%{?_isa} = %{version}-%{release}
+Requires: glib2-devel
+Requires: %{name}-utils-devel%{?_isa} = %{version}-%{release}
+
+%description zfs-devel
+This package contains header files and pkg-config files needed for development
+with the libblockdev-zfs plugin/library.
+%endif
+
 %if %{with_tools}
 %package tools
 Summary:    Various nice tools based on libblockdev
@@ -623,6 +647,10 @@ Requires: %{name}-smartmontools%{?_isa} = %{version}-%{release}
 Requires: %{name}-swap%{?_isa} = %{version}-%{release}
 %endif
 
+%if %{with_zfs}
+Requires: %{name}-zfs%{?_isa} = %{version}-%{release}
+%endif
+
 %ifarch s390 s390x
 Requires: %{name}-s390%{?_isa} = %{version}-%{release}
 %endif
@@ -717,6 +745,10 @@ find %{buildroot} -type f -name "*.la" | xargs %{__rm}
 
 %if %{with_swap}
 %ldconfig_scriptlets swap
+%endif
+
+%if %{with_zfs}
+%ldconfig_scriptlets zfs
 %endif
 
 %ifarch s390 s390x
@@ -936,6 +968,17 @@ find %{buildroot} -type f -name "*.la" | xargs %{__rm}
 %{_libdir}/libbd_swap.so
 %dir %{_includedir}/blockdev
 %{_includedir}/blockdev/swap.h
+%endif
+
+
+%if %{with_zfs}
+%files zfs
+%{_libdir}/libbd_zfs.so.*
+
+%files zfs-devel
+%{_libdir}/libbd_zfs.so
+%dir %{_includedir}/blockdev
+%{_includedir}/blockdev/zfs.h
 %endif
 
 

--- a/src/lib/plugin_apis/zfs 2.api
+++ b/src/lib/plugin_apis/zfs 2.api
@@ -1,0 +1,55 @@
+#include <glib.h>
+#include <glib-object.h>
+#include <blockdev/utils.h>
+
+#ifndef BD_ZFS_API
+#define BD_ZFS_API
+
+GQuark bd_zfs_error_quark (void) {
+    return g_quark_from_static_string ("g-bd-zfs-error-quark");
+}
+
+#define BD_ZFS_ERROR bd_zfs_error_quark ()
+typedef enum {
+    BD_ZFS_ERROR_TECH_UNAVAIL,
+    BD_ZFS_ERROR_POOL,
+    BD_ZFS_ERROR_DATASET,
+    BD_ZFS_ERROR_SNAPSHOT,
+    BD_ZFS_ERROR_PARSE,
+    BD_ZFS_ERROR_FAIL,
+    BD_ZFS_ERROR_NOEXIST,
+    BD_ZFS_ERROR_BUSY,
+    BD_ZFS_ERROR_ENCRYPT,
+} BDZFSError;
+
+typedef enum {
+    BD_ZFS_TECH_POOL = 0,
+    BD_ZFS_TECH_VDEV,
+    BD_ZFS_TECH_DATASET,
+    BD_ZFS_TECH_SNAPSHOT,
+    BD_ZFS_TECH_ENCRYPTION,
+    BD_ZFS_TECH_ZVOL,
+    BD_ZFS_TECH_MAINTENANCE,
+} BDZFSTech;
+
+typedef enum {
+    BD_ZFS_TECH_MODE_CREATE = 1 << 0,
+    BD_ZFS_TECH_MODE_DELETE = 1 << 1,
+    BD_ZFS_TECH_MODE_MODIFY = 1 << 2,
+    BD_ZFS_TECH_MODE_QUERY  = 1 << 3,
+} BDZFSTechMode;
+
+/**
+ * bd_zfs_is_tech_avail:
+ * @tech: the queried tech
+ * @mode: a bit mask of queried modes of operation (#BDZFSTechMode) for @tech
+ * @error: (out) (optional): place to store error (details about why the @tech-@mode combination is not available)
+ *
+ * Returns: whether the @tech-@mode combination is available -- both
+ *          require the ``zpool`` and ``zfs`` utilities
+ *
+ * Tech category: always available
+ */
+gboolean bd_zfs_is_tech_avail (BDZFSTech tech, guint64 mode, GError **error);
+
+#endif /* BD_ZFS_API */

--- a/src/plugins/fs/generic.c
+++ b/src/plugins/fs/generic.c
@@ -1222,6 +1222,25 @@ static gboolean device_operation (const gchar *device, const gchar *fstype, BDFS
             default:
                 g_assert_not_reached ();
         }
+    } else if (g_strcmp0 (detected_fstype, "zfs") == 0 || g_strcmp0 (detected_fstype, "zfs_member") == 0) {
+        switch (op) {
+            case BD_FS_RESIZE:
+                break;  /* not supported through generic dispatch */
+            case BD_FS_REPAIR:
+                break;  /* not supported through generic dispatch */
+            case BD_FS_CHECK:
+                break;  /* not supported through generic dispatch */
+            case BD_FS_LABEL:
+                break;  /* ZFS has no traditional label; use pool name via top-level plugin */
+            case BD_FS_LABEL_CHECK:
+                return bd_fs_zfs_check_label (label, error);
+            case BD_FS_UUID:
+                break;  /* ZFS GUIDs cannot be changed */
+            case BD_FS_UUID_CHECK:
+                return bd_fs_zfs_check_uuid (uuid, error);
+            default:
+                g_assert_not_reached ();
+        }
     }
     switch (op) {
         case BD_FS_RESIZE:
@@ -1513,6 +1532,13 @@ guint64 bd_fs_get_size (const gchar *device, const gchar *fstype, GError **error
             bd_fs_udf_info_free (info);
         }
         return size;
+    } else if (g_strcmp0 (detected_fstype, "zfs") == 0 || g_strcmp0 (detected_fstype, "zfs_member") == 0) {
+        BDFSZfsInfo *info = bd_fs_zfs_get_info (device, error);
+        if (info) {
+            size = info->size;
+            bd_fs_zfs_info_free (info);
+        }
+        return size;
     } else {
         g_set_error (error, BD_FS_ERROR, BD_FS_ERROR_NOT_SUPPORTED,
                     "Getting size of filesystem '%s' is not supported.", detected_fstype);
@@ -1591,6 +1617,13 @@ guint64 bd_fs_get_free_space (const gchar *device, const gchar *fstype, GError *
         if (info) {
             size = info->free_space;
             bd_fs_btrfs_info_free (info);
+        }
+        return size;
+    } else if (g_strcmp0 (detected_fstype, "zfs") == 0 || g_strcmp0 (detected_fstype, "zfs_member") == 0) {
+        BDFSZfsInfo *info = bd_fs_zfs_get_info (device, error);
+        if (info) {
+            size = info->free_space;
+            bd_fs_zfs_info_free (info);
         }
         return size;
     } else {

--- a/src/plugins/fs/zfs 2.c
+++ b/src/plugins/fs/zfs 2.c
@@ -1,0 +1,246 @@
+/*
+ * Copyright (C) 2024  Red Hat, Inc.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, see <http://www.gnu.org/licenses/>.
+ *
+ * Author: Razvan Vilt
+ */
+
+#include <blockdev/utils.h>
+#include <check_deps.h>
+#include <string.h>
+
+#include "zfs.h"
+#include "fs.h"
+#include "common.h"
+
+/* ZFS FS sub-plugin: SEVERELY RESTRICTED per security review.
+ * Only get_info, check_label, and check_uuid are functional.
+ * All other operations (mkfs, check, repair, resize, set_label, set_uuid)
+ * return NOT_SUPPORTED to prevent pool-level operations from being
+ * triggered through the generic FS dispatch path.
+ */
+
+static volatile guint avail_deps = 0;
+static GMutex deps_check_lock;
+
+#define DEPS_ZPOOL 0
+#define DEPS_ZPOOL_MASK (1 << DEPS_ZPOOL)
+#define DEPS_LAST 1
+
+static const UtilDep deps[DEPS_LAST] = {
+    {"zpool", NULL, NULL, NULL},
+};
+
+
+/**
+ * bd_fs_zfs_is_tech_avail:
+ * @tech: the queried tech
+ * @mode: a bit mask of queried modes of operation (#BDFSTechMode) for @tech
+ * @error: (out) (optional): place to store error (details about why the @tech-@mode combination is not available)
+ *
+ * Returns: whether the @tech-@mode combination is available -- supported by the
+ *          plugin implementation and having all the runtime dependencies available
+ */
+G_GNUC_INTERNAL gboolean
+bd_fs_zfs_is_tech_avail (BDFSTech tech G_GNUC_UNUSED, guint64 mode, GError **error) {
+    /* only QUERY mode is supported */
+    if (mode & ~BD_FS_TECH_MODE_QUERY) {
+        g_set_error (error, BD_FS_ERROR, BD_FS_ERROR_TECH_UNAVAIL,
+                     "ZFS FS operations other than query are not supported through the generic FS interface. "
+                     "Use the BD_PLUGIN_ZFS top-level plugin instead.");
+        return FALSE;
+    }
+
+    return check_deps (&avail_deps, DEPS_ZPOOL_MASK, deps, DEPS_LAST, &deps_check_lock, error);
+}
+
+/**
+ * bd_fs_zfs_info_copy: (skip)
+ *
+ * Creates a new copy of @data.
+ */
+BDFSZfsInfo* bd_fs_zfs_info_copy (BDFSZfsInfo *data) {
+    if (data == NULL)
+        return NULL;
+
+    BDFSZfsInfo *ret = g_new0 (BDFSZfsInfo, 1);
+
+    ret->label = g_strdup (data->label);
+    ret->uuid = g_strdup (data->uuid);
+    ret->size = data->size;
+    ret->free_space = data->free_space;
+
+    return ret;
+}
+
+/**
+ * bd_fs_zfs_info_free: (skip)
+ *
+ * Frees @data.
+ */
+void bd_fs_zfs_info_free (BDFSZfsInfo *data) {
+    if (data == NULL)
+        return;
+
+    g_free (data->label);
+    g_free (data->uuid);
+    g_free (data);
+}
+
+/**
+ * bd_fs_zfs_check_label:
+ * @label: label to check
+ * @error: (out) (optional): place to store error
+ *
+ * Returns: whether @label is a valid label for a ZFS pool or not
+ *          (reason is provided in @error)
+ *
+ * Tech category: always available
+ */
+gboolean bd_fs_zfs_check_label (const gchar *label, GError **error) {
+    /* ZFS pool names: 1-255 chars, alphanumeric + _ - . : (no leading digit, no leading -) */
+    if (label == NULL || *label == '\0') {
+        g_set_error (error, BD_FS_ERROR, BD_FS_ERROR_LABEL_INVALID,
+                     "ZFS pool name cannot be empty");
+        return FALSE;
+    }
+
+    if (strlen (label) > 255) {
+        g_set_error (error, BD_FS_ERROR, BD_FS_ERROR_LABEL_INVALID,
+                     "ZFS pool name too long (max 255 characters)");
+        return FALSE;
+    }
+
+    /* Must not start with digit or dash */
+    if (g_ascii_isdigit (label[0]) || label[0] == '-') {
+        g_set_error (error, BD_FS_ERROR, BD_FS_ERROR_LABEL_INVALID,
+                     "ZFS pool name must not start with a digit or dash");
+        return FALSE;
+    }
+
+    /* Only alphanumeric, underscore, dash, period, colon */
+    for (const gchar *p = label; *p; p++) {
+        if (!g_ascii_isalnum (*p) && *p != '_' && *p != '-' && *p != '.' && *p != ':') {
+            g_set_error (error, BD_FS_ERROR, BD_FS_ERROR_LABEL_INVALID,
+                         "ZFS pool name contains invalid character '%c'", *p);
+            return FALSE;
+        }
+    }
+
+    /* Reserved names */
+    if (g_strcmp0 (label, "mirror") == 0 || g_strcmp0 (label, "raidz") == 0 ||
+        g_strcmp0 (label, "draid") == 0 || g_strcmp0 (label, "spare") == 0 ||
+        g_strcmp0 (label, "log") == 0 || g_strcmp0 (label, "cache") == 0 ||
+        g_strcmp0 (label, "special") == 0 || g_strcmp0 (label, "dedup") == 0) {
+        g_set_error (error, BD_FS_ERROR, BD_FS_ERROR_LABEL_INVALID,
+                     "ZFS pool name '%s' is reserved", label);
+        return FALSE;
+    }
+
+    return TRUE;
+}
+
+/**
+ * bd_fs_zfs_check_uuid:
+ * @uuid: UUID to check
+ * @error: (out) (optional): place to store error
+ *
+ * Returns: whether @uuid is a valid UUID (pool GUID) for ZFS or not
+ *          (reason is provided in @error)
+ *
+ * Tech category: always available
+ */
+gboolean bd_fs_zfs_check_uuid (const gchar *uuid, GError **error) {
+    /* ZFS pool GUIDs are 64-bit unsigned integers, not standard UUIDs */
+    if (uuid == NULL || *uuid == '\0') {
+        g_set_error (error, BD_FS_ERROR, BD_FS_ERROR_UUID_INVALID,
+                     "ZFS pool GUID cannot be empty");
+        return FALSE;
+    }
+
+    /* Validate it's a valid uint64 */
+    gchar *end = NULL;
+    g_ascii_strtoull (uuid, &end, 10);
+    if (end == uuid || *end != '\0') {
+        g_set_error (error, BD_FS_ERROR, BD_FS_ERROR_UUID_INVALID,
+                     "ZFS pool GUID must be a decimal number");
+        return FALSE;
+    }
+
+    return TRUE;
+}
+
+/**
+ * bd_fs_zfs_get_info:
+ * @device: the device containing the file system to get info for
+ * @error: (out) (optional): place to store error (if any)
+ *
+ * Returns: (transfer full): information about the ZFS file system on @device or
+ *                           %NULL in case of error
+ *
+ * Tech category: %BD_FS_TECH_ZFS-%BD_FS_TECH_MODE_QUERY
+ */
+BDFSZfsInfo* bd_fs_zfs_get_info (const gchar *device, GError **error) {
+    const gchar *argv[] = {"zpool", "list", "-H", "-p", "-o", "name,guid,size,free", NULL};
+    gchar *output = NULL;
+    gboolean success;
+
+    if (!check_deps (&avail_deps, DEPS_ZPOOL_MASK, deps, DEPS_LAST, &deps_check_lock, error))
+        return NULL;
+
+    success = bd_utils_exec_and_capture_output (argv, NULL, &output, error);
+    if (!success) {
+        g_free (output);
+        return NULL;
+    }
+
+    if (output == NULL || *output == '\0') {
+        g_free (output);
+        g_set_error (error, BD_FS_ERROR, BD_FS_ERROR_FAIL,
+                     "No ZFS pools found");
+        return NULL;
+    }
+
+    /* Parse first line: name\tguid\tsize\tfree */
+    gchar **lines = g_strsplit (output, "\n", 2);
+    g_free (output);
+
+    if (lines[0] == NULL || *lines[0] == '\0') {
+        g_strfreev (lines);
+        g_set_error (error, BD_FS_ERROR, BD_FS_ERROR_FAIL,
+                     "Failed to parse ZFS pool info");
+        return NULL;
+    }
+
+    gchar **fields = g_strsplit (lines[0], "\t", -1);
+    g_strfreev (lines);
+
+    guint n_fields = g_strv_length (fields);
+    if (n_fields < 4) {
+        g_strfreev (fields);
+        g_set_error (error, BD_FS_ERROR, BD_FS_ERROR_FAIL,
+                     "Unexpected zpool list output format");
+        return NULL;
+    }
+
+    BDFSZfsInfo *info = g_new0 (BDFSZfsInfo, 1);
+    info->label = g_strdup (fields[0]);        /* pool name */
+    info->uuid = g_strdup (fields[1]);         /* pool GUID */
+    info->size = g_ascii_strtoull (fields[2], NULL, 10);
+    info->free_space = g_ascii_strtoull (fields[3], NULL, 10);
+
+    g_strfreev (fields);
+    return info;
+}

--- a/src/plugins/fs/zfs 2.h
+++ b/src/plugins/fs/zfs 2.h
@@ -1,0 +1,21 @@
+#include <glib.h>
+#include <blockdev/utils.h>
+
+#ifndef BD_FS_ZFS
+#define BD_FS_ZFS
+
+typedef struct BDFSZfsInfo {
+    gchar *label;
+    gchar *uuid;
+    guint64 size;
+    guint64 free_space;
+} BDFSZfsInfo;
+
+BDFSZfsInfo* bd_fs_zfs_info_copy (BDFSZfsInfo *data);
+void bd_fs_zfs_info_free (BDFSZfsInfo *data);
+
+gboolean bd_fs_zfs_check_label (const gchar *label, GError **error);
+gboolean bd_fs_zfs_check_uuid (const gchar *uuid, GError **error);
+BDFSZfsInfo* bd_fs_zfs_get_info (const gchar *device, GError **error);
+
+#endif  /* BD_FS_ZFS */

--- a/src/plugins/zfs 2.c
+++ b/src/plugins/zfs 2.c
@@ -1,0 +1,92 @@
+/*
+ * Copyright (C) 2026  Red Hat, Inc.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <glib.h>
+#include <blockdev/utils.h>
+
+#include "zfs.h"
+#include "check_deps.h"
+
+/**
+ * SECTION: zfs
+ * @short_description: plugin for operations with ZFS pools and datasets
+ * @title: ZFS
+ * @include: zfs.h
+ *
+ * A plugin for operations with ZFS pools and datasets using CLI tools.
+ */
+
+/**
+ * bd_zfs_error_quark: (skip)
+ */
+GQuark bd_zfs_error_quark (void)
+{
+    return g_quark_from_static_string ("g-bd-zfs-error-quark");
+}
+
+static volatile guint avail_deps = 0;
+static GMutex deps_check_lock;
+
+#define DEPS_ZPOOL 0
+#define DEPS_ZPOOL_MASK (1 << DEPS_ZPOOL)
+#define DEPS_ZFS 1
+#define DEPS_ZFS_MASK (1 << DEPS_ZFS)
+#define DEPS_LAST 2
+
+static const UtilDep deps[DEPS_LAST] = {
+    {"zpool", NULL, NULL, NULL},
+    {"zfs", NULL, NULL, NULL},
+};
+
+/**
+ * bd_zfs_init:
+ *
+ * Initializes the plugin. **This function is called automatically by the
+ * library's initialization functions.**
+ *
+ */
+gboolean bd_zfs_init (void) {
+    /* nothing to do here */
+    return TRUE;
+}
+
+/**
+ * bd_zfs_close:
+ *
+ * Cleans up after the plugin. **This function is called automatically by the
+ * library's functions that unload it.**
+ *
+ */
+void bd_zfs_close (void) {
+    /* nothing to do here */
+}
+
+/**
+ * bd_zfs_is_tech_avail:
+ * @tech: the queried tech
+ * @mode: a bit mask of queried modes of operation (#BDZFSTechMode) for @tech
+ * @error: (out) (optional): place to store error (details about why the @tech-@mode combination is not available)
+ *
+ * Returns: whether the @tech-@mode combination is available -- both combos
+ *          require the ``zpool`` and ``zfs`` utilities
+ *
+ * Tech category: always available
+ */
+gboolean bd_zfs_is_tech_avail (BDZFSTech tech G_GNUC_UNUSED, guint64 mode G_GNUC_UNUSED, GError **error) {
+    /* all techs require both zpool and zfs tools */
+    return check_deps (&avail_deps, DEPS_ZPOOL_MASK | DEPS_ZFS_MASK, deps, DEPS_LAST, &deps_check_lock, error);
+}

--- a/src/plugins/zfs 2.h
+++ b/src/plugins/zfs 2.h
@@ -1,0 +1,51 @@
+#include <glib.h>
+#include <blockdev/utils.h>
+
+#ifndef BD_ZFS
+#define BD_ZFS
+
+GQuark bd_zfs_error_quark (void);
+#define BD_ZFS_ERROR bd_zfs_error_quark ()
+typedef enum {
+    BD_ZFS_ERROR_TECH_UNAVAIL,
+    BD_ZFS_ERROR_POOL,
+    BD_ZFS_ERROR_DATASET,
+    BD_ZFS_ERROR_SNAPSHOT,
+    BD_ZFS_ERROR_PARSE,
+    BD_ZFS_ERROR_FAIL,
+    BD_ZFS_ERROR_NOEXIST,
+    BD_ZFS_ERROR_BUSY,
+    BD_ZFS_ERROR_ENCRYPT,
+} BDZFSError;
+
+typedef enum {
+    BD_ZFS_TECH_POOL = 0,
+    BD_ZFS_TECH_VDEV,
+    BD_ZFS_TECH_DATASET,
+    BD_ZFS_TECH_SNAPSHOT,
+    BD_ZFS_TECH_ENCRYPTION,
+    BD_ZFS_TECH_ZVOL,
+    BD_ZFS_TECH_MAINTENANCE,
+} BDZFSTech;
+
+typedef enum {
+    BD_ZFS_TECH_MODE_CREATE = 1 << 0,
+    BD_ZFS_TECH_MODE_DELETE = 1 << 1,
+    BD_ZFS_TECH_MODE_MODIFY = 1 << 2,
+    BD_ZFS_TECH_MODE_QUERY  = 1 << 3,
+} BDZFSTechMode;
+
+/*
+ * If using the plugin as a standalone library, the following functions should
+ * be called to:
+ *
+ * init()       - initialize the plugin, returning TRUE on success
+ * close()      - clean after the plugin at the end or if no longer used
+ *
+ */
+gboolean bd_zfs_init (void);
+void bd_zfs_close (void);
+
+gboolean bd_zfs_is_tech_avail (BDZFSTech tech, guint64 mode, GError **error);
+
+#endif  /* BD_ZFS */


### PR DESCRIPTION
## Summary
- Add libblockdev-zfs / libblockdev-zfs-devel RPM subpackages to spec
- Wire check_label/check_uuid into generic dispatch (safe, read-only)
- Wire get_size/get_free_space into generic dispatch
- mkfs/check/repair/resize remain unsupported (security by design)

🤖 Generated with [Claude Code](https://claude.com/claude-code)