### PR TITLE
Fix build: GI headers + zvol GTK-Doc comments

### DIFF
--- a/src/lib/Makefile.am
+++ b/src/lib/Makefile.am
@@ -32,7 +32,8 @@ GIHEADERS = ${builddir}/plugin_apis/mdraid.h \
 	${builddir}/plugin_apis/fs.h \
 	${builddir}/plugin_apis/nvdimm.h \
 	${builddir}/plugin_apis/nvme.h \
-	${builddir}/plugin_apis/smart.h
+	${builddir}/plugin_apis/smart.h \
+	${builddir}/plugin_apis/zfs.h
 
 GIHEADERS += $(wildcard ${srcdir}/../utils/*.[ch])
 GIHEADERS += blockdev.c blockdev.h plugins.c plugins.h

--- a/src/lib/plugin_apis/zfs.api
+++ b/src/lib/plugin_apis/zfs.api
@@ -1250,13 +1250,49 @@ gboolean bd_zfs_encryption_change_key (const gchar *dataset, const gchar *new_ke
  */
 BDZFSKeyStatus bd_zfs_encryption_key_status (const gchar *dataset, GError **error);
 
-/** bd_zfs_zvol_create: @name: (not nullable): name of the zvol to create (e.g. "pool/zvol") @size: size of the zvol in bytes @sparse: whether to create a sparse (thin provisioned) zvol @extra: (nullable) (array zero-terminated=1): extra options for zvol creation @error: (out) (optional): place to store error (if any) Returns: whether the zvol was successfully created or not Tech category: %BD_ZFS_TECH_ZVOL-%BD_ZFS_TECH_MODE_CREATE */
+/**
+ * bd_zfs_zvol_create:
+ * @name: (not nullable): name of the zvol to create (e.g. "pool/zvol")
+ * @size: size of the zvol in bytes
+ * @sparse: whether to create a sparse (thin provisioned) zvol
+ * @extra: (nullable) (array zero-terminated=1): extra options for zvol creation
+ * @error: (out) (optional): place to store error (if any)
+ *
+ * Creates a new ZFS zvol (block volume).
+ *
+ * Returns: whether the zvol was successfully created or not
+ *
+ * Tech category: %BD_ZFS_TECH_ZVOL-%BD_ZFS_TECH_MODE_CREATE
+ */
 gboolean bd_zfs_zvol_create (const gchar *name, guint64 size, gboolean sparse, const BDExtraArg **extra, GError **error);
 
-/** bd_zfs_zvol_destroy: @name: (not nullable): name of the zvol to destroy @recursive: whether to recursively destroy all dependents @force: whether to force the destruction @error: (out) (optional): place to store error (if any) Returns: whether the zvol was successfully destroyed or not Tech category: %BD_ZFS_TECH_ZVOL-%BD_ZFS_TECH_MODE_DELETE */
+/**
+ * bd_zfs_zvol_destroy:
+ * @name: (not nullable): name of the zvol to destroy
+ * @recursive: whether to recursively destroy all dependents
+ * @force: whether to force the destruction
+ * @error: (out) (optional): place to store error (if any)
+ *
+ * Destroys a ZFS zvol (block volume).
+ *
+ * Returns: whether the zvol was successfully destroyed or not
+ *
+ * Tech category: %BD_ZFS_TECH_ZVOL-%BD_ZFS_TECH_MODE_DELETE
+ */
 gboolean bd_zfs_zvol_destroy (const gchar *name, gboolean recursive, gboolean force, GError **error);
 
-/** bd_zfs_zvol_resize: @name: (not nullable): name of the zvol to resize @new_size: new size for the zvol in bytes @error: (out) (optional): place to store error (if any) Returns: whether the zvol was successfully resized or not Tech category: %BD_ZFS_TECH_ZVOL-%BD_ZFS_TECH_MODE_MODIFY */
+/**
+ * bd_zfs_zvol_resize:
+ * @name: (not nullable): name of the zvol to resize
+ * @new_size: new size for the zvol in bytes
+ * @error: (out) (optional): place to store error (if any)
+ *
+ * Resizes a ZFS zvol (block volume).
+ *
+ * Returns: whether the zvol was successfully resized or not
+ *
+ * Tech category: %BD_ZFS_TECH_ZVOL-%BD_ZFS_TECH_MODE_MODIFY
+ */
 gboolean bd_zfs_zvol_resize (const gchar *name, guint64 new_size, GError **error);
 
 #endif /* BD_ZFS_API */


### PR DESCRIPTION
## Summary
- Add zfs.h to GIHEADERS in src/lib/Makefile.am for GObject Introspection
- Fix zvol GTK-Doc comment format in zfs.api (g-ir-scanner fatal warnings)

Discovered during container build testing on Ubuntu 25.10 with ZFS 2.3.4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)