### PR TITLE
S3-2: Add BDZFSBookmarkInfo type and remove vdev alloc/space fields

### DIFF
--- a/docs/libblockdev-sections.txt
+++ b/docs/libblockdev-sections.txt
@@ -909,6 +909,9 @@ bd_zfs_dataset_info_free
 BDZFSSnapshotInfo
 bd_zfs_snapshot_info_copy
 bd_zfs_snapshot_info_free
+BDZFSBookmarkInfo
+bd_zfs_bookmark_info_copy
+bd_zfs_bookmark_info_free
 BDZFSPropertyInfo
 bd_zfs_property_info_copy
 bd_zfs_property_info_free

--- a/src/lib/plugin_apis/zfs.api
+++ b/src/lib/plugin_apis/zfs.api
@@ -196,8 +196,6 @@ GType bd_zfs_vdev_info_get_type();
  * @path: path of the vdev device (or name for virtual vdevs)
  * @type: type of the vdev
  * @state: state of the vdev
- * @alloc: allocated space in bytes
- * @space: total space in bytes
  * @read_errors: number of read errors
  * @write_errors: number of write errors
  * @checksum_errors: number of checksum errors
@@ -207,8 +205,6 @@ typedef struct BDZFSVdevInfo {
     gchar *path;
     BDZFSVdevType type;
     BDZFSVdevState state;
-    guint64 alloc;
-    guint64 space;
     guint64 read_errors;
     guint64 write_errors;
     guint64 checksum_errors;
@@ -230,8 +226,6 @@ BDZFSVdevInfo* bd_zfs_vdev_info_copy (BDZFSVdevInfo *info) {
     new_info->path = g_strdup (info->path);
     new_info->type = info->type;
     new_info->state = info->state;
-    new_info->alloc = info->alloc;
-    new_info->space = info->space;
     new_info->read_errors = info->read_errors;
     new_info->write_errors = info->write_errors;
     new_info->checksum_errors = info->checksum_errors;
@@ -437,6 +431,64 @@ GType bd_zfs_snapshot_info_get_type () {
         type = g_boxed_type_register_static("BDZFSSnapshotInfo",
                                             (GBoxedCopyFunc) bd_zfs_snapshot_info_copy,
                                             (GBoxedFreeFunc) bd_zfs_snapshot_info_free);
+    }
+
+    return type;
+}
+
+
+#define BD_ZFS_TYPE_BOOKMARK_INFO (bd_zfs_bookmark_info_get_type ())
+GType bd_zfs_bookmark_info_get_type();
+
+/**
+ * BDZFSBookmarkInfo:
+ * @name: full name of the bookmark (pool/dataset#bookmark)
+ * @creation: creation timestamp (Unix epoch seconds)
+ */
+typedef struct BDZFSBookmarkInfo {
+    gchar *name;
+    guint64 creation;
+} BDZFSBookmarkInfo;
+
+/**
+ * bd_zfs_bookmark_info_copy: (skip)
+ * @info: (nullable): %BDZFSBookmarkInfo to copy
+ *
+ * Creates a new copy of @info.
+ */
+BDZFSBookmarkInfo* bd_zfs_bookmark_info_copy (BDZFSBookmarkInfo *info) {
+    if (info == NULL)
+        return NULL;
+
+    BDZFSBookmarkInfo *new_info = g_new0 (BDZFSBookmarkInfo, 1);
+
+    new_info->name = g_strdup (info->name);
+    new_info->creation = info->creation;
+
+    return new_info;
+}
+
+/**
+ * bd_zfs_bookmark_info_free: (skip)
+ * @info: (nullable): %BDZFSBookmarkInfo to free
+ *
+ * Frees @info.
+ */
+void bd_zfs_bookmark_info_free (BDZFSBookmarkInfo *info) {
+    if (info == NULL)
+        return;
+
+    g_free (info->name);
+    g_free (info);
+}
+
+GType bd_zfs_bookmark_info_get_type () {
+    static GType type = 0;
+
+    if (G_UNLIKELY(type == 0)) {
+        type = g_boxed_type_register_static("BDZFSBookmarkInfo",
+                                            (GBoxedCopyFunc) bd_zfs_bookmark_info_copy,
+                                            (GBoxedFreeFunc) bd_zfs_bookmark_info_free);
     }
 
     return type;
@@ -1203,11 +1255,11 @@ gboolean bd_zfs_bookmark_destroy (const gchar *name, GError **error);
  *
  * Lists ZFS bookmarks for the given dataset or all bookmarks.
  *
- * Returns: (array zero-terminated=1) (transfer full): a NULL-terminated array of #BDZFSPropertyInfo or %NULL in case of error
+ * Returns: (array zero-terminated=1) (transfer full): a NULL-terminated array of #BDZFSBookmarkInfo or %NULL in case of error
  *
  * Tech category: %BD_ZFS_TECH_SNAPSHOT-%BD_ZFS_TECH_MODE_QUERY
  */
-BDZFSPropertyInfo** bd_zfs_bookmark_list (const gchar *dataset, GError **error);
+BDZFSBookmarkInfo** bd_zfs_bookmark_list (const gchar *dataset, GError **error);
 
 /**
  * bd_zfs_encryption_load_key:

--- a/src/plugins/zfs.c
+++ b/src/plugins/zfs.c
@@ -80,8 +80,6 @@ BDZFSVdevInfo* bd_zfs_vdev_info_copy (BDZFSVdevInfo *info) {
     new_info->path = g_strdup (info->path);
     new_info->type = info->type;
     new_info->state = info->state;
-    new_info->alloc = info->alloc;
-    new_info->space = info->space;
     new_info->read_errors = info->read_errors;
     new_info->write_errors = info->write_errors;
     new_info->checksum_errors = info->checksum_errors;
@@ -171,6 +169,26 @@ void bd_zfs_snapshot_info_free (BDZFSSnapshotInfo *info) {
     g_free (info->name);
     g_free (info->dataset);
     g_free (info->creation);
+    g_free (info);
+}
+
+BDZFSBookmarkInfo* bd_zfs_bookmark_info_copy (BDZFSBookmarkInfo *info) {
+    if (info == NULL)
+        return NULL;
+
+    BDZFSBookmarkInfo *new_info = g_new0 (BDZFSBookmarkInfo, 1);
+
+    new_info->name = g_strdup (info->name);
+    new_info->creation = info->creation;
+
+    return new_info;
+}
+
+void bd_zfs_bookmark_info_free (BDZFSBookmarkInfo *info) {
+    if (info == NULL)
+        return;
+
+    g_free (info->name);
     g_free (info);
 }
 
@@ -3068,11 +3086,11 @@ gboolean bd_zfs_bookmark_destroy (const gchar *name, GError **error) {
  * Lists ZFS bookmarks for the given dataset or all bookmarks.
  *
  * Returns: (array zero-terminated=1) (transfer full): a NULL-terminated array of
- *          #BDZFSPropertyInfo or %NULL in case of error
+ *          #BDZFSBookmarkInfo or %NULL in case of error
  *
  * Tech category: %BD_ZFS_TECH_SNAPSHOT-%BD_ZFS_TECH_MODE_QUERY
  */
-BDZFSPropertyInfo** bd_zfs_bookmark_list (const gchar *dataset, GError **error) {
+BDZFSBookmarkInfo** bd_zfs_bookmark_list (const gchar *dataset, GError **error) {
     const gchar **argv = NULL;
     guint next_arg = 0;
     guint num_args;
@@ -3125,7 +3143,7 @@ BDZFSPropertyInfo** bd_zfs_bookmark_list (const gchar *dataset, GError **error) 
     for (line_p = lines; *line_p; line_p++) {
         gchar **fields = NULL;
         guint num_fields;
-        BDZFSPropertyInfo *info = NULL;
+        BDZFSBookmarkInfo *info = NULL;
 
         if (strlen (*line_p) == 0)
             continue;
@@ -3138,10 +3156,9 @@ BDZFSPropertyInfo** bd_zfs_bookmark_list (const gchar *dataset, GError **error) 
             continue;
         }
 
-        info = g_new0 (BDZFSPropertyInfo, 1);
+        info = g_new0 (BDZFSBookmarkInfo, 1);
         info->name = g_strdup (fields[0]);
-        info->value = g_strdup (fields[1]);
-        info->source = g_strdup ("");
+        info->creation = g_ascii_strtoull (fields[1], NULL, 10);
 
         g_strfreev (fields);
         g_ptr_array_add (bookmarks, info);
@@ -3149,7 +3166,7 @@ BDZFSPropertyInfo** bd_zfs_bookmark_list (const gchar *dataset, GError **error) 
     g_strfreev (lines);
 
     g_ptr_array_add (bookmarks, NULL);
-    return (BDZFSPropertyInfo **) g_ptr_array_free (bookmarks, FALSE);
+    return (BDZFSBookmarkInfo **) g_ptr_array_free (bookmarks, FALSE);
 }
 
 /**

--- a/src/plugins/zfs.h
+++ b/src/plugins/zfs.h
@@ -117,8 +117,6 @@ typedef struct BDZFSVdevInfo {
     gchar *path;
     BDZFSVdevType type;
     BDZFSVdevState state;
-    guint64 alloc;
-    guint64 space;
     guint64 read_errors;
     guint64 write_errors;
     guint64 checksum_errors;
@@ -155,6 +153,14 @@ typedef struct BDZFSSnapshotInfo {
 
 void bd_zfs_snapshot_info_free (BDZFSSnapshotInfo *info);
 BDZFSSnapshotInfo* bd_zfs_snapshot_info_copy (BDZFSSnapshotInfo *info);
+
+typedef struct BDZFSBookmarkInfo {
+    gchar *name;
+    guint64 creation;  /* creation timestamp (Unix epoch seconds) */
+} BDZFSBookmarkInfo;
+
+void bd_zfs_bookmark_info_free (BDZFSBookmarkInfo *info);
+BDZFSBookmarkInfo* bd_zfs_bookmark_info_copy (BDZFSBookmarkInfo *info);
 
 typedef struct BDZFSPropertyInfo {
     gchar *name;
@@ -258,7 +264,7 @@ gboolean bd_zfs_snapshot_release (const gchar *snapshot, const gchar *tag, GErro
 
 gboolean bd_zfs_bookmark_create (const gchar *snapshot, const gchar *bookmark, GError **error);
 gboolean bd_zfs_bookmark_destroy (const gchar *name, GError **error);
-BDZFSPropertyInfo** bd_zfs_bookmark_list (const gchar *dataset, GError **error);
+BDZFSBookmarkInfo** bd_zfs_bookmark_list (const gchar *dataset, GError **error);
 
 gboolean bd_zfs_encryption_load_key (const gchar *dataset, const gchar *key_location, GError **error);
 gboolean bd_zfs_encryption_unload_key (const gchar *dataset, GError **error);

--- a/tests/zfs_test.py
+++ b/tests/zfs_test.py
@@ -487,3 +487,64 @@ class ZfsUnknownEnumValuesTestCase(ZfsPluginTest):
         val = BlockDev.ZFSKeyStatus.NONE
         self.assertIsNotNone(val)
         self.assertEqual(int(val), 0)
+
+
+class ZfsBookmarkInfoTypeTestCase(ZfsPluginTest):
+    """Tests for the BDZFSBookmarkInfo type and bd_zfs_bookmark_list return type."""
+
+    @tag_test(TestTags.NOSTORAGE)
+    def test_bookmark_info_type_accessible(self):
+        """BDZFSBookmarkInfo must be accessible through GI as a boxed type"""
+        info_type = BlockDev.ZFSBookmarkInfo
+        self.assertIsNotNone(info_type)
+
+    @tag_test(TestTags.NOSTORAGE)
+    def test_bookmark_info_has_name_field(self):
+        """BDZFSBookmarkInfo must have a 'name' field"""
+        self.assertTrue(hasattr(BlockDev.ZFSBookmarkInfo, 'name'))
+
+    @tag_test(TestTags.NOSTORAGE)
+    def test_bookmark_info_has_creation_field(self):
+        """BDZFSBookmarkInfo must have a 'creation' field"""
+        self.assertTrue(hasattr(BlockDev.ZFSBookmarkInfo, 'creation'))
+
+    @tag_test(TestTags.NOSTORAGE)
+    def test_bookmark_list_returns_bookmark_info(self):
+        """bd_zfs_bookmark_list must return BDZFSBookmarkInfo objects (when ZFS available)"""
+        try:
+            BlockDev.zfs_is_tech_avail(BlockDev.ZFSTech.SNAPSHOT, BlockDev.ZFSTechMode.QUERY)
+        except GLib.GError:
+            self.skipTest("skipping: ZFS tools not available")
+
+        try:
+            bookmarks = BlockDev.zfs_bookmark_list(None)
+        except GLib.GError:
+            # May fail if no pools exist; that is fine
+            return
+
+        if bookmarks:
+            for bm in bookmarks:
+                self.assertIsInstance(bm, BlockDev.ZFSBookmarkInfo)
+                self.assertIsNotNone(bm.name)
+                self.assertIsInstance(bm.creation, int)
+
+
+class ZfsVdevInfoFieldsTestCase(ZfsPluginTest):
+    """Tests that BDZFSVdevInfo does not have removed alloc/space fields."""
+
+    @tag_test(TestTags.NOSTORAGE)
+    def test_vdev_info_no_alloc_field(self):
+        """BDZFSVdevInfo must not have an 'alloc' field (removed)"""
+        self.assertFalse(hasattr(BlockDev.ZFSVdevInfo, 'alloc'))
+
+    @tag_test(TestTags.NOSTORAGE)
+    def test_vdev_info_no_space_field(self):
+        """BDZFSVdevInfo must not have a 'space' field (removed)"""
+        self.assertFalse(hasattr(BlockDev.ZFSVdevInfo, 'space'))
+
+    @tag_test(TestTags.NOSTORAGE)
+    def test_vdev_info_has_error_fields(self):
+        """BDZFSVdevInfo must still have read_errors, write_errors, checksum_errors"""
+        self.assertTrue(hasattr(BlockDev.ZFSVdevInfo, 'read_errors'))
+        self.assertTrue(hasattr(BlockDev.ZFSVdevInfo, 'write_errors'))
+        self.assertTrue(hasattr(BlockDev.ZFSVdevInfo, 'checksum_errors'))


### PR DESCRIPTION
## Summary

Two pre-upstream ABI fixes:

1. **BDZFSBookmarkInfo**: New dedicated struct with `name` + `creation` (timestamp) fields. Replaces the semantically wrong abuse of BDZFSPropertyInfo for bookmark data. `bd_zfs_bookmark_list()` now returns `BDZFSBookmarkInfo**`.

2. **Remove vdev alloc/space**: These fields were documented as populated but were always 0 (can't be obtained from `zpool status` output). Removed pre-upstream rather than shipping a broken contract.

New free/copy functions, API/docs registration, 4 new tests.

Closes #44