### PR TITLE
S4-5: Harden synthesized -o option payloads against comma injection

### DIFF
--- a/src/plugins/zfs.c
+++ b/src/plugins/zfs.c
@@ -2575,6 +2575,11 @@ gboolean bd_zfs_dataset_mount (const gchar *name, const gchar *mountpoint, const
                          "Mountpoint cannot be empty or start with '-'");
             return FALSE;
         }
+        if (strchr (mountpoint, ',')) {
+            g_set_error (error, BD_ZFS_ERROR, BD_ZFS_ERROR_FAIL,
+                         "Mountpoint path cannot contain commas: %s", mountpoint);
+            return FALSE;
+        }
     }
 
     if (!check_deps (&avail_deps, DEPS_ZFS_MASK, deps, DEPS_LAST, &deps_check_lock, error))
@@ -3296,6 +3301,11 @@ gboolean bd_zfs_encryption_change_key (const gchar *dataset, const gchar *new_ke
         if (*new_key_location == '-') {
             g_set_error (error, BD_ZFS_ERROR, BD_ZFS_ERROR_FAIL,
                          "New key location cannot start with '-'");
+            return FALSE;
+        }
+        if (strchr (new_key_location, ',')) {
+            g_set_error (error, BD_ZFS_ERROR, BD_ZFS_ERROR_FAIL,
+                         "New key location cannot contain commas: %s", new_key_location);
             return FALSE;
         }
     }

--- a/tests/zfs_test.py
+++ b/tests/zfs_test.py
@@ -271,6 +271,20 @@ class ZfsOptionInjectionTestCase(ZfsPluginTest):
         with self.assertRaisesRegex(GLib.GError, "cannot start with '-'"):
             BlockDev.zfs_encryption_change_key("pool/ds", "--help", None)
 
+    # ---- synthesized option payload hardening (comma in -o key=value) ----
+
+    @tag_test(TestTags.NOSTORAGE)
+    def test_dataset_mount_rejects_comma_in_mountpoint(self):
+        """dataset_mount must reject mountpoint containing commas (option separator in -o)"""
+        with self.assertRaisesRegex(GLib.GError, "cannot contain commas"):
+            BlockDev.zfs_dataset_mount("pool/ds", "/mnt/a,rw", None)
+
+    @tag_test(TestTags.NOSTORAGE)
+    def test_encryption_change_key_rejects_comma_in_key_location(self):
+        """encryption_change_key must reject new_key_location containing commas"""
+        with self.assertRaisesRegex(GLib.GError, "cannot contain commas"):
+            BlockDev.zfs_encryption_change_key("pool/ds", "file:///key,file", None)
+
     # NOTE: bd_zfs_pool_get_vdevs() bugs (double-free on depth overflow and
     # regex recompilation in hot loop) were fixed in commit
     # fix/s1-4-vdev-parser-safety and verified by code review + defensive


### PR DESCRIPTION
## Summary

Hardens synthesized `-o key=value` arguments against comma-based option separator injection (re-review item 49):

- **dataset_mount**: Rejects mountpoints containing commas (would be parsed as multiple mount options in `-o mountpoint=<path>`)
- **encryption_change_key**: Rejects key locations containing commas (same risk in `-o keylocation=<value>`)

Property values (pool/dataset set_property) and load-key location are NOT affected — they use standalone argv elements, not `-o` concatenation.

2 new tests.

Closes #54