### PR TITLE
S4-1/2: Fix ZFS packaging runtime deps + test infrastructure integration

### DIFF
--- a/dist/libblockdev.spec.in
+++ b/dist/libblockdev.spec.in
@@ -534,6 +534,9 @@ with the libblockdev-swap plugin/library.
 %package zfs
 Summary:     The ZFS plugin for the libblockdev library
 Requires: %{name}-utils%{?_isa} = %{version}-%{release}
+Requires: /usr/sbin/zpool
+Requires: /usr/sbin/zfs
+Requires: /usr/sbin/zdb
 
 %description zfs
 The libblockdev library plugin (and in the same time a standalone library)

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -63,6 +63,10 @@ if WITH_SMARTMONTOOLS
 PLUGINS += smartmontools
 endif
 
+if WITH_ZFS
+PLUGINS += zfs
+endif
+
 if WITH_TOOLS
 PLUGINS += tools
 endif


### PR DESCRIPTION
## Summary

- **Packaging**: Added path-based runtime Requires for /usr/sbin/zpool, /usr/sbin/zfs, /usr/sbin/zdb to the ZFS subpackage (portable across distros)
- **Test infra**: Added ZFS to PLUGINS list in tests/Makefile.am behind WITH_ZFS conditional

Config and skip entries verified as already correct.

Closes #50, closes #51