### PR TITLE
Unify pool-name validators: FS-side check_label mirrors canonical validate_pool_name

### DIFF
--- a/src/plugins/fs/zfs.c
+++ b/src/plugins/fs/zfs.c
@@ -264,48 +264,60 @@ gboolean bd_fs_zfs_set_label (const gchar *device, const gchar *label, GError **
  * @label: label to check
  * @error: (out) (optional): place to store error
  *
+ * Validates that @label is a valid ZFS pool name per canonical OpenZFS naming
+ * rules (see zpool_name_valid() in OpenZFS).  This function intentionally
+ * mirrors the logic in bd_zfs_validate_pool_name() from the ZFS top-level
+ * plugin; the two cannot call each other at runtime because libbd_fs and
+ * libbd_zfs are separate shared libraries.  Any changes to naming rules must
+ * be applied to both functions.
+ *
+ * Deliberate deviation from upstream OpenZFS: spaces are rejected even though
+ * OpenZFS technically allows them in pool names.  Spaces break shell quoting,
+ * D-Bus object paths, and systemd mount units; no sane deployment uses them.
+ *
  * Returns: whether @label is a valid label for a ZFS pool or not
  *          (reason is provided in @error)
  *
  * Tech category: always available
  */
 gboolean bd_fs_zfs_check_label (const gchar *label, GError **error) {
-    /* ZFS pool names: 1-255 chars, alphanumeric + _ - . : (no leading digit, no leading -) */
     if (label == NULL || *label == '\0') {
         g_set_error (error, BD_FS_ERROR, BD_FS_ERROR_LABEL_INVALID,
-                     "ZFS pool name cannot be empty");
+                     "ZFS pool name cannot be NULL or empty");
         return FALSE;
     }
 
-    if (strlen (label) > 255) {
+    /* Max pool name length: ZFS_MAX_DATASET_NAME_LEN(256) - 2 - strlen("$ORIGIN")*2 = 240 */
+    if (strlen (label) >= 240) {
         g_set_error (error, BD_FS_ERROR, BD_FS_ERROR_LABEL_INVALID,
-                     "ZFS pool name too long (max 255 characters)");
+                     "ZFS pool name exceeds maximum length of 239 characters");
         return FALSE;
     }
 
-    /* Must not start with digit or dash */
-    if (g_ascii_isdigit (label[0]) || label[0] == '-') {
+    /* Must begin with a letter */
+    if (!g_ascii_isalpha (label[0])) {
         g_set_error (error, BD_FS_ERROR, BD_FS_ERROR_LABEL_INVALID,
-                     "ZFS pool name must not start with a digit or dash");
+                     "ZFS pool name must begin with a letter: '%s'", label);
         return FALSE;
     }
 
-    /* Only alphanumeric, underscore, dash, period, colon */
-    for (const gchar *p = label; *p; p++) {
+    /* Only allowed characters: alphanumerics, underscore, hyphen, period, colon */
+    for (const gchar *p = label; *p != '\0'; p++) {
         if (!g_ascii_isalnum (*p) && *p != '_' && *p != '-' && *p != '.' && *p != ':') {
             g_set_error (error, BD_FS_ERROR, BD_FS_ERROR_LABEL_INVALID,
-                         "ZFS pool name contains invalid character '%c'", *p);
+                         "ZFS pool name contains invalid character '%c': '%s'", *p, label);
             return FALSE;
         }
     }
 
-    /* Reserved names */
-    if (g_strcmp0 (label, "mirror") == 0 || g_strcmp0 (label, "raidz") == 0 ||
-        g_strcmp0 (label, "draid") == 0 || g_strcmp0 (label, "spare") == 0 ||
-        g_strcmp0 (label, "log") == 0 || g_strcmp0 (label, "cache") == 0 ||
-        g_strcmp0 (label, "special") == 0 || g_strcmp0 (label, "dedup") == 0) {
+    /* Reserved vdev type prefixes per OpenZFS zpool_name_valid() */
+    if (g_ascii_strncasecmp (label, "mirror", 6) == 0 ||
+        g_ascii_strncasecmp (label, "raidz", 5) == 0 ||
+        g_ascii_strncasecmp (label, "draid", 5) == 0 ||
+        g_ascii_strncasecmp (label, "spare", 5) == 0 ||
+        g_ascii_strcasecmp (label, "log") == 0) {
         g_set_error (error, BD_FS_ERROR, BD_FS_ERROR_LABEL_INVALID,
-                     "ZFS pool name '%s' is reserved", label);
+                     "ZFS pool name '%s' conflicts with a reserved vdev type name", label);
         return FALSE;
     }
 

--- a/tests/fs_tests/zfs_test.py
+++ b/tests/fs_tests/zfs_test.py
@@ -118,6 +118,218 @@ class ZfsTestOptionDeviceRejection(ZfsNoDevTestCase):
             BlockDev.fs_zfs_get_info("--help")
 
 
+class ZfsTestCheckLabel(ZfsNoDevTestCase):
+    """Tests for bd_fs_zfs_check_label() — must match canonical OpenZFS rules
+    from bd_zfs_validate_pool_name() in the ZFS top-level plugin."""
+
+    # ---- valid names ----
+
+    @tag_test(TestTags.NOSTORAGE)
+    def test_valid_simple_name(self):
+        """'tank' is a valid pool name"""
+        self.assertTrue(BlockDev.fs_zfs_check_label("tank"))
+
+    @tag_test(TestTags.NOSTORAGE)
+    def test_valid_longer_name(self):
+        """'mypool' is a valid pool name"""
+        self.assertTrue(BlockDev.fs_zfs_check_label("mypool"))
+
+    @tag_test(TestTags.NOSTORAGE)
+    def test_valid_underscore(self):
+        """'pool_1' is a valid pool name (underscore allowed)"""
+        self.assertTrue(BlockDev.fs_zfs_check_label("pool_1"))
+
+    @tag_test(TestTags.NOSTORAGE)
+    def test_valid_hyphen(self):
+        """'test-pool' is a valid pool name (hyphen allowed)"""
+        self.assertTrue(BlockDev.fs_zfs_check_label("test-pool"))
+
+    @tag_test(TestTags.NOSTORAGE)
+    def test_valid_period(self):
+        """'data.backup' is a valid pool name (period allowed)"""
+        self.assertTrue(BlockDev.fs_zfs_check_label("data.backup"))
+
+    @tag_test(TestTags.NOSTORAGE)
+    def test_valid_colon(self):
+        """'pool:1' is a valid pool name (colon allowed)"""
+        self.assertTrue(BlockDev.fs_zfs_check_label("pool:1"))
+
+    @tag_test(TestTags.NOSTORAGE)
+    def test_valid_single_letter(self):
+        """'z' is a valid pool name (single letter)"""
+        self.assertTrue(BlockDev.fs_zfs_check_label("z"))
+
+    @tag_test(TestTags.NOSTORAGE)
+    def test_valid_max_length(self):
+        """A 239-character name is valid (max allowed)"""
+        name = "a" * 239
+        self.assertTrue(BlockDev.fs_zfs_check_label(name))
+
+    @tag_test(TestTags.NOSTORAGE)
+    def test_valid_cache(self):
+        """'cache' is NOT a reserved pool name in OpenZFS"""
+        self.assertTrue(BlockDev.fs_zfs_check_label("cache"))
+
+    @tag_test(TestTags.NOSTORAGE)
+    def test_valid_special(self):
+        """'special' is NOT a reserved pool name in OpenZFS"""
+        self.assertTrue(BlockDev.fs_zfs_check_label("special"))
+
+    @tag_test(TestTags.NOSTORAGE)
+    def test_valid_dedup(self):
+        """'dedup' is NOT a reserved pool name in OpenZFS"""
+        self.assertTrue(BlockDev.fs_zfs_check_label("dedup"))
+
+    @tag_test(TestTags.NOSTORAGE)
+    def test_valid_c_digit(self):
+        """'c0d0' is valid — c+digit check was removed from OpenZFS in 2021"""
+        self.assertTrue(BlockDev.fs_zfs_check_label("c0d0"))
+
+    @tag_test(TestTags.NOSTORAGE)
+    def test_valid_C_digit(self):
+        """'C9pool' is valid — c+digit check was removed from OpenZFS in 2021"""
+        self.assertTrue(BlockDev.fs_zfs_check_label("C9pool"))
+
+    # ---- invalid: empty / NULL ----
+
+    @tag_test(TestTags.NOSTORAGE)
+    def test_invalid_empty(self):
+        """Empty string is not a valid pool name"""
+        with self.assertRaisesRegex(GLib.GError, "cannot be NULL or empty"):
+            BlockDev.fs_zfs_check_label("")
+
+    # ---- invalid: starts with digit ----
+
+    @tag_test(TestTags.NOSTORAGE)
+    def test_invalid_starts_with_digit(self):
+        """Pool name starting with a digit is invalid"""
+        with self.assertRaisesRegex(GLib.GError, "must begin with a letter"):
+            BlockDev.fs_zfs_check_label("1pool")
+
+    # ---- invalid: starts with special char ----
+
+    @tag_test(TestTags.NOSTORAGE)
+    def test_invalid_starts_with_dash(self):
+        """Pool name starting with '-' is invalid"""
+        with self.assertRaisesRegex(GLib.GError, "must begin with a letter"):
+            BlockDev.fs_zfs_check_label("-pool")
+
+    @tag_test(TestTags.NOSTORAGE)
+    def test_invalid_starts_with_underscore(self):
+        """Pool name starting with '_' is invalid (must begin with letter)"""
+        with self.assertRaisesRegex(GLib.GError, "must begin with a letter"):
+            BlockDev.fs_zfs_check_label("_pool")
+
+    # ---- invalid: bad characters ----
+
+    @tag_test(TestTags.NOSTORAGE)
+    def test_invalid_space(self):
+        """Pool name containing a space is invalid"""
+        with self.assertRaisesRegex(GLib.GError, "contains invalid character"):
+            BlockDev.fs_zfs_check_label("my pool")
+
+    @tag_test(TestTags.NOSTORAGE)
+    def test_invalid_slash(self):
+        """Pool name containing '/' is invalid"""
+        with self.assertRaisesRegex(GLib.GError, "contains invalid character"):
+            BlockDev.fs_zfs_check_label("pool/child")
+
+    @tag_test(TestTags.NOSTORAGE)
+    def test_invalid_at_sign(self):
+        """Pool name containing '@' is invalid"""
+        with self.assertRaisesRegex(GLib.GError, "contains invalid character"):
+            BlockDev.fs_zfs_check_label("pool@snap")
+
+    @tag_test(TestTags.NOSTORAGE)
+    def test_invalid_hash(self):
+        """Pool name containing '#' is invalid"""
+        with self.assertRaisesRegex(GLib.GError, "contains invalid character"):
+            BlockDev.fs_zfs_check_label("pool#bm")
+
+    # ---- invalid: reserved names (exact match for log, prefix match for others) ----
+
+    @tag_test(TestTags.NOSTORAGE)
+    def test_invalid_mirror(self):
+        """'mirror' is a reserved vdev type prefix"""
+        with self.assertRaisesRegex(GLib.GError, "conflicts with a reserved vdev type name"):
+            BlockDev.fs_zfs_check_label("mirror")
+
+    @tag_test(TestTags.NOSTORAGE)
+    def test_invalid_mirror_prefix(self):
+        """'mirror0' is rejected (prefix match)"""
+        with self.assertRaisesRegex(GLib.GError, "conflicts with a reserved vdev type name"):
+            BlockDev.fs_zfs_check_label("mirror0")
+
+    @tag_test(TestTags.NOSTORAGE)
+    def test_invalid_raidz(self):
+        """'raidz' is a reserved vdev type prefix"""
+        with self.assertRaisesRegex(GLib.GError, "conflicts with a reserved vdev type name"):
+            BlockDev.fs_zfs_check_label("raidz")
+
+    @tag_test(TestTags.NOSTORAGE)
+    def test_invalid_raidz1(self):
+        """'raidz1' is rejected (prefix match)"""
+        with self.assertRaisesRegex(GLib.GError, "conflicts with a reserved vdev type name"):
+            BlockDev.fs_zfs_check_label("raidz1")
+
+    @tag_test(TestTags.NOSTORAGE)
+    def test_invalid_raidz2(self):
+        """'raidz2' is rejected (prefix match)"""
+        with self.assertRaisesRegex(GLib.GError, "conflicts with a reserved vdev type name"):
+            BlockDev.fs_zfs_check_label("raidz2")
+
+    @tag_test(TestTags.NOSTORAGE)
+    def test_invalid_spare(self):
+        """'spare' is a reserved vdev type prefix"""
+        with self.assertRaisesRegex(GLib.GError, "conflicts with a reserved vdev type name"):
+            BlockDev.fs_zfs_check_label("spare")
+
+    @tag_test(TestTags.NOSTORAGE)
+    def test_invalid_spare1(self):
+        """'spare1' is rejected (prefix match)"""
+        with self.assertRaisesRegex(GLib.GError, "conflicts with a reserved vdev type name"):
+            BlockDev.fs_zfs_check_label("spare1")
+
+    @tag_test(TestTags.NOSTORAGE)
+    def test_invalid_draid(self):
+        """'draid' is a reserved vdev type prefix"""
+        with self.assertRaisesRegex(GLib.GError, "conflicts with a reserved vdev type name"):
+            BlockDev.fs_zfs_check_label("draid")
+
+    @tag_test(TestTags.NOSTORAGE)
+    def test_invalid_draid2(self):
+        """'draid2' is rejected (prefix match)"""
+        with self.assertRaisesRegex(GLib.GError, "conflicts with a reserved vdev type name"):
+            BlockDev.fs_zfs_check_label("draid2")
+
+    @tag_test(TestTags.NOSTORAGE)
+    def test_invalid_log(self):
+        """'log' is a reserved vdev type name (exact match)"""
+        with self.assertRaisesRegex(GLib.GError, "conflicts with a reserved vdev type name"):
+            BlockDev.fs_zfs_check_label("log")
+
+    @tag_test(TestTags.NOSTORAGE)
+    def test_reserved_case_insensitive(self):
+        """Reserved name check is case-insensitive"""
+        with self.assertRaisesRegex(GLib.GError, "conflicts with a reserved vdev type name"):
+            BlockDev.fs_zfs_check_label("MIRROR")
+
+    @tag_test(TestTags.NOSTORAGE)
+    def test_reserved_mixed_case(self):
+        """Reserved name check is case-insensitive (mixed case)"""
+        with self.assertRaisesRegex(GLib.GError, "conflicts with a reserved vdev type name"):
+            BlockDev.fs_zfs_check_label("RaidZ")
+
+    # ---- invalid: too long ----
+
+    @tag_test(TestTags.NOSTORAGE)
+    def test_invalid_too_long(self):
+        """A 240-character name exceeds the maximum"""
+        name = "a" * 240
+        with self.assertRaisesRegex(GLib.GError, "exceeds maximum length"):
+            BlockDev.fs_zfs_check_label(name)
+
+
 class ZfsTestGetInfoNoFallback(ZfsNoDevTestCase):
 
     def test_get_info_fails_on_nonexistent_device(self):


### PR DESCRIPTION
## Summary
- Replace divergent FS-side validation with logic matching canonical `bd_zfs_validate_pool_name()`
- Fix max length (255→239), first-char rule, reserved prefix matching, case sensitivity
- Stop rejecting `cache`/`special`/`dedup` (they are valid pool names)
- Document deliberate no-spaces policy deviation from OpenZFS
- 30 new FS-side validation tests mirroring ZFS-side test suite

Closes #61

## Test plan
- [x] 30 new tests for `bd_fs_zfs_check_label()` covering all canonical rules
- [x] Tests mirror `ZfsPoolNameValidationTestCase` from zfs_test.py

🤖 Generated with [Claude Code](https://claude.com/claude-code)