### PR TITLE
Fix bd_fs_zfs_set_label: fail closed instead of unsafe export/reimport rename

### DIFF
--- a/src/plugins/fs/zfs.c
+++ b/src/plugins/fs/zfs.c
@@ -26,10 +26,13 @@
 #include "common.h"
 
 /* ZFS FS sub-plugin: RESTRICTED per security review.
- * Supported: get_info, check_label, check_uuid, set_label (pool rename).
- * Not supported: mkfs, check, repair, resize, set_uuid.
+ * Supported: get_info, check_label, check_uuid.
+ * Not supported: mkfs, check, repair, resize, set_uuid, set_label.
  * mkfs/check/repair/resize are semantically incompatible with ZFS pools
  * and must go through the BD_PLUGIN_ZFS top-level plugin instead.
+ * set_label (pool rename) requires export/reimport and cannot safely
+ * preserve the original import context for rollback; it must go through
+ * a dedicated pool rename operation instead.
  */
 
 static volatile guint avail_deps = 0;
@@ -58,11 +61,11 @@ static const UtilDep deps[DEPS_LAST] = {
  */
 G_GNUC_INTERNAL gboolean
 bd_fs_zfs_is_tech_avail (BDFSTech tech G_GNUC_UNUSED, guint64 mode, GError **error) {
-    /* only QUERY and SET_LABEL modes are supported */
-    guint64 supported = BD_FS_TECH_MODE_QUERY | BD_FS_TECH_MODE_SET_LABEL;
+    /* only QUERY mode is supported */
+    guint64 supported = BD_FS_TECH_MODE_QUERY;
     if (mode & ~supported) {
         g_set_error (error, BD_FS_ERROR, BD_FS_ERROR_TECH_UNAVAIL,
-                     "ZFS FS operations other than query and set_label are not supported through the generic FS interface. "
+                     "ZFS FS operations other than query are not supported through the generic FS interface. "
                      "Use the BD_PLUGIN_ZFS top-level plugin instead.");
         return FALSE;
     }
@@ -181,82 +184,20 @@ resolve_pool_name_from_device (const gchar *device, GError **error) {
  * @label: the new pool name (label)
  * @error: (out) (optional): place to store error (if any)
  *
- * Renames the ZFS pool that @device belongs to. This is done by
- * exporting the pool and re-importing it with the new name.
- * The pool must not have any busy datasets (mounted filesystems, etc.).
- * The pool name is resolved from @device using zdb(8). Both zpool and zdb
- * must be available.
+ * ZFS pool rename requires export/reimport and cannot safely preserve the
+ * original import context (search dirs, altroot, properties, etc.) for
+ * rollback. This function always returns an error directing the caller to
+ * use a dedicated pool rename operation instead.
  *
- * Returns: whether the pool was successfully renamed or not
+ * Returns: always %FALSE
  *
  * Tech category: %BD_FS_TECH_ZFS-%BD_FS_TECH_MODE_SET_LABEL
  */
-gboolean bd_fs_zfs_set_label (const gchar *device, const gchar *label, GError **error) {
-    /* To rename a ZFS pool we need the current pool name.
-     * The 'device' parameter is a block device that's a pool member.
-     * We resolve the pool name using zdb -l (no fallback).
-     * Then: zpool export <oldname> && zpool import <oldname> <newname>
-     */
-    gboolean success;
-    gchar *old_name = NULL;
-
-    if (!check_deps (&avail_deps, DEPS_ZPOOL_MASK | DEPS_ZDB_MASK, deps, DEPS_LAST, &deps_check_lock, error))
-        return FALSE;
-
-    /* Validate the new label */
-    if (!bd_fs_zfs_check_label (label, error))
-        return FALSE;
-
-    /* Resolve the pool name from the device using zdb -l.
-     * No fallback to zpool list -- that would be a fail-open vulnerability
-     * in multi-pool systems. */
-    old_name = resolve_pool_name_from_device (device, error);
-    if (!old_name)
-        return FALSE;
-
-    /* If same name, nothing to do */
-    if (g_strcmp0 (old_name, label) == 0) {
-        g_free (old_name);
-        return TRUE;
-    }
-
-    /* Export the pool */
-    {
-        const gchar *argv_export[] = {"zpool", "export", old_name, NULL};
-        success = bd_utils_exec_and_report_error (argv_export, NULL, error);
-        if (!success) {
-            g_prefix_error (error, "Failed to export pool '%s' for rename: ", old_name);
-            g_free (old_name);
-            return FALSE;
-        }
-    }
-
-    /* Import with new name */
-    {
-        const gchar *argv_import[] = {"zpool", "import", old_name, label, NULL};
-        success = bd_utils_exec_and_report_error (argv_import, NULL, error);
-        if (!success) {
-            /* Try to re-import with old name to recover */
-            GError *recover_error = NULL;
-            gboolean recovery_success;
-            const gchar *argv_recover[] = {"zpool", "import", old_name, NULL};
-            recovery_success = bd_utils_exec_and_report_error (argv_recover, NULL, &recover_error);
-
-            if (!recovery_success) {
-                /* Both rename import and recovery failed — the pool may be in an exported state */
-                g_prefix_error (error, "Recovery import also failed (%s); pool may be exported: ",
-                                recover_error->message);
-                g_error_free (recover_error);
-            }
-
-            g_prefix_error (error, "Failed to import pool '%s' as '%s': ", old_name, label);
-            g_free (old_name);
-            return FALSE;
-        }
-    }
-
-    g_free (old_name);
-    return TRUE;
+gboolean bd_fs_zfs_set_label (const gchar *device G_GNUC_UNUSED, const gchar *label G_GNUC_UNUSED, GError **error) {
+    g_set_error (error, BD_FS_ERROR, BD_FS_ERROR_NOT_SUPPORTED,
+                 "ZFS pool rename requires export/reimport and cannot be safely performed "
+                 "through the filesystem label interface. Use a dedicated pool rename operation instead.");
+    return FALSE;
 }
 
 /**

--- a/tests/fs_tests/zfs_test.py
+++ b/tests/fs_tests/zfs_test.py
@@ -17,8 +17,7 @@ class ZfsTestAvailability(ZfsNoDevTestCase):
         """Verify that it is possible to check ZFS tech availability"""
         try:
             available = BlockDev.fs_is_tech_avail(BlockDev.FSTech.ZFS,
-                                                  BlockDev.FSTechMode.QUERY |
-                                                  BlockDev.FSTechMode.SET_LABEL)
+                                                  BlockDev.FSTechMode.QUERY)
             self.assertTrue(available)
         except GLib.GError:
             self.skipTest("skipping ZFS: zpool or zdb not available")
@@ -37,8 +36,11 @@ class ZfsTestAvailability(ZfsNoDevTestCase):
         with self.assertRaisesRegex(GLib.GError, "not supported"):
             BlockDev.fs_is_tech_avail(BlockDev.FSTech.ZFS, BlockDev.FSTechMode.RESIZE)
 
+        with self.assertRaisesRegex(GLib.GError, "not supported"):
+            BlockDev.fs_is_tech_avail(BlockDev.FSTech.ZFS, BlockDev.FSTechMode.SET_LABEL)
+
     def test_zfs_zdb_dep(self):
-        """Verify that zdb is required for ZFS QUERY and SET_LABEL modes"""
+        """Verify that zdb is required for ZFS QUERY mode"""
         BlockDev.reinit(self.requested_plugins, True, None)
 
         # without zdb, QUERY should fail
@@ -46,64 +48,35 @@ class ZfsTestAvailability(ZfsNoDevTestCase):
             with self.assertRaisesRegex(GLib.GError, "The 'zdb' utility is not available"):
                 BlockDev.fs_is_tech_avail(BlockDev.FSTech.ZFS, BlockDev.FSTechMode.QUERY)
 
-        # without zdb, SET_LABEL should fail
-        with utils.fake_path(all_but="zdb"):
-            with self.assertRaisesRegex(GLib.GError, "The 'zdb' utility is not available"):
-                BlockDev.fs_is_tech_avail(BlockDev.FSTech.ZFS, BlockDev.FSTechMode.SET_LABEL)
-
-        # without zpool, both modes should fail
-        with utils.fake_path(all_but="zpool"):
-            with self.assertRaisesRegex(GLib.GError, "The 'zpool' utility is not available"):
-                BlockDev.fs_is_tech_avail(BlockDev.FSTech.ZFS, BlockDev.FSTechMode.SET_LABEL)
-
+        # without zpool, QUERY should fail
         with utils.fake_path(all_but="zpool"):
             with self.assertRaisesRegex(GLib.GError, "The 'zpool' utility is not available"):
                 BlockDev.fs_is_tech_avail(BlockDev.FSTech.ZFS, BlockDev.FSTechMode.QUERY)
 
 
-class ZfsTestSetLabelNoFallback(ZfsNoDevTestCase):
+class ZfsTestSetLabelUnsupported(ZfsNoDevTestCase):
 
-    def test_set_label_fails_on_nonexistent_device(self):
-        """Verify that set_label fails when pool cannot be resolved from device"""
-        try:
-            BlockDev.fs_is_tech_avail(BlockDev.FSTech.ZFS,
-                                      BlockDev.FSTechMode.SET_LABEL)
-        except GLib.GError:
-            self.skipTest("skipping ZFS: zpool or zdb not available")
+    def test_set_label_always_fails(self):
+        """Verify that set_label always returns an error
 
-        with self.assertRaisesRegex(GLib.GError, "Failed to determine ZFS pool name"):
-            BlockDev.fs_zfs_set_label("/dev/nonexistent_device_xyz", "newpool")
-
-    def test_set_label_no_zpool_list_fallback(self):
-        """Verify that set_label does not fall back to 'zpool list' when zdb fails
-
-        This is the critical security test: in a multi-pool system, falling
-        back to 'the first pool from zpool list' could rename the wrong pool.
-        The function must fail closed when zdb cannot resolve the device.
+        ZFS pool rename requires export/reimport and cannot safely preserve
+        the original import context for rollback.  The FS label interface
+        must refuse the operation unconditionally.
         """
-        try:
-            BlockDev.fs_is_tech_avail(BlockDev.FSTech.ZFS,
-                                      BlockDev.FSTechMode.SET_LABEL)
-        except GLib.GError:
-            self.skipTest("skipping ZFS: zpool or zdb not available")
+        with self.assertRaisesRegex(GLib.GError, "cannot be safely performed"):
+            BlockDev.fs_zfs_set_label("/dev/sda", "newpool")
 
-        # A bogus device that zdb -l will fail on should cause a hard failure,
-        # NOT a fallback to zpool list
-        with self.assertRaisesRegex(GLib.GError, "Failed to determine ZFS pool name"):
-            BlockDev.fs_zfs_set_label("/dev/null", "newpool")
+    def test_set_label_error_message(self):
+        """Verify that the error message directs to a dedicated rename operation"""
+        with self.assertRaisesRegex(GLib.GError, "dedicated pool rename operation"):
+            BlockDev.fs_zfs_set_label("/dev/sda", "newpool")
 
 
 class ZfsTestOptionDeviceRejection(ZfsNoDevTestCase):
 
-    def test_set_label_rejects_option_device(self):
-        """set_label must reject device paths starting with '-'"""
-        try:
-            BlockDev.fs_is_tech_avail(BlockDev.FSTech.ZFS,
-                                      BlockDev.FSTechMode.SET_LABEL)
-        except GLib.GError:
-            self.skipTest("skipping ZFS: zpool or zdb not available")
-
-        with self.assertRaisesRegex(GLib.GError, "cannot start with '-'"):
+    def test_set_label_rejects_unconditionally(self):
+        """set_label must reject all calls regardless of arguments"""
+        with self.assertRaisesRegex(GLib.GError, "cannot be safely performed"):
             BlockDev.fs_zfs_set_label("--help", "newname")
 
     def test_get_info_rejects_option_device(self):


### PR DESCRIPTION
## Summary
- Replace unsafe export/reimport pool rename with fail-closed error return
- Remove SET_LABEL from supported FS tech modes
- Pool rename requires export/reimport and cannot safely preserve import context
- Function signature preserved (public API), returns BD_FS_ERROR_NOT_SUPPORTED
- Tests updated to verify the rejection behavior

Closes #63

## Test plan
- [x] Tests verify set_label always returns error with correct message
- [x] Availability tests updated to reflect SET_LABEL as unsupported
- [x] Other FS functions (get_info, check_label) unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)