### PR TITLE
Fix vdev type inference: use stat() to distinguish file-backed vdevs from disks

### DIFF
--- a/src/lib/plugin_apis/zfs.api
+++ b/src/lib/plugin_apis/zfs.api
@@ -1476,4 +1476,20 @@ const gchar* bd_zfs_get_zfs_version (GError **error);
  */
 gboolean bd_zfs_validate_pool_name (const gchar *name, GError **error);
 
+/**
+ * bd_zfs_vdev_infer_type:
+ * @name: the vdev name or path as reported by zpool status
+ *
+ * Infers the vdev type from the vdev name. For absolute paths, stat() is
+ * used to distinguish block devices (%BD_ZFS_VDEV_TYPE_DISK) from regular
+ * files (%BD_ZFS_VDEV_TYPE_FILE). Short device names (e.g. "sda", "nvme0n1")
+ * are assumed to be disks. Keyword prefixes like "mirror-", "raidz1-", etc.
+ * map to their respective vdev types.
+ *
+ * Returns: the inferred #BDZFSVdevType
+ *
+ * Tech category: always available
+ */
+BDZFSVdevType bd_zfs_vdev_infer_type (const gchar *name);
+
 #endif /* BD_ZFS_API */

--- a/src/plugins/zfs.c
+++ b/src/plugins/zfs.c
@@ -17,6 +17,7 @@
 
 #include <glib.h>
 #include <string.h>
+#include <sys/stat.h>
 #include <blockdev/utils.h>
 
 #include "zfs.h"
@@ -605,7 +606,19 @@ static BDZFSVdevState parse_vdev_state (const gchar *state_str) {
         return BD_ZFS_VDEV_STATE_UNKNOWN;
 }
 
-static BDZFSVdevType infer_vdev_type (const gchar *name) {
+/**
+ * bd_zfs_vdev_infer_type:
+ * @name: the vdev name or path as reported by zpool status
+ *
+ * Infers the vdev type from the vdev name. For absolute paths, stat() is
+ * used to distinguish block devices (%BD_ZFS_VDEV_TYPE_DISK) from regular
+ * files (%BD_ZFS_VDEV_TYPE_FILE). Short device names (e.g. "sda", "nvme0n1")
+ * are assumed to be disks. Keyword prefixes like "mirror-", "raidz1-", etc.
+ * map to their respective vdev types.
+ *
+ * Returns: the inferred #BDZFSVdevType
+ */
+BDZFSVdevType bd_zfs_vdev_infer_type (const gchar *name) {
     if (g_str_has_prefix (name, "mirror-"))
         return BD_ZFS_VDEV_TYPE_MIRROR;
     else if (g_str_has_prefix (name, "raidz1-") || g_str_has_prefix (name, "raidz-"))
@@ -626,9 +639,18 @@ static BDZFSVdevType infer_vdev_type (const gchar *name) {
         return BD_ZFS_VDEV_TYPE_SPECIAL;
     else if (g_strcmp0 (name, "dedup") == 0)
         return BD_ZFS_VDEV_TYPE_DEDUP;
-    else if (name[0] == '/' || g_str_has_prefix (name, "sd") || g_str_has_prefix (name, "nvme") ||
-             g_str_has_prefix (name, "vd") || g_str_has_prefix (name, "hd") ||
-             g_str_has_prefix (name, "xvd") || g_str_has_prefix (name, "da"))
+    else if (name[0] == '/') {
+        struct stat st;
+        if (stat (name, &st) == 0) {
+            if (S_ISBLK (st.st_mode))
+                return BD_ZFS_VDEV_TYPE_DISK;
+            else if (S_ISREG (st.st_mode))
+                return BD_ZFS_VDEV_TYPE_FILE;
+        }
+        return BD_ZFS_VDEV_TYPE_UNKNOWN;
+    } else if (g_str_has_prefix (name, "sd") || g_str_has_prefix (name, "nvme") ||
+               g_str_has_prefix (name, "vd") || g_str_has_prefix (name, "hd") ||
+               g_str_has_prefix (name, "xvd") || g_str_has_prefix (name, "da"))
         return BD_ZFS_VDEV_TYPE_DISK;
     else
         return BD_ZFS_VDEV_TYPE_UNKNOWN;
@@ -1273,7 +1295,7 @@ BDZFSVdevInfo** bd_zfs_pool_get_vdevs (const gchar *name, GError **error) {
         vdev->read_errors = g_ascii_strtoull (fields[2], NULL, 10);
         vdev->write_errors = g_ascii_strtoull (fields[3], NULL, 10);
         vdev->checksum_errors = g_ascii_strtoull (fields[4], NULL, 10);
-        vdev->type = infer_vdev_type (fields[0]);
+        vdev->type = bd_zfs_vdev_infer_type (fields[0]);
         vdev->children = NULL;
 
         g_strfreev (fields);

--- a/src/plugins/zfs.h
+++ b/src/plugins/zfs.h
@@ -281,4 +281,6 @@ const gchar* bd_zfs_get_zfs_version (GError **error);
 
 gboolean bd_zfs_validate_pool_name (const gchar *name, GError **error);
 
+BDZFSVdevType bd_zfs_vdev_infer_type (const gchar *name);
+
 #endif  /* BD_ZFS */

--- a/tests/zfs_test.py
+++ b/tests/zfs_test.py
@@ -1,3 +1,4 @@
+import tempfile
 import unittest
 
 import overrides_hack
@@ -1180,3 +1181,137 @@ class ZfsVdevInfoFieldsTestCase(ZfsPluginTest):
         self.assertTrue(hasattr(BlockDev.ZFSVdevInfo, 'read_errors'))
         self.assertTrue(hasattr(BlockDev.ZFSVdevInfo, 'write_errors'))
         self.assertTrue(hasattr(BlockDev.ZFSVdevInfo, 'checksum_errors'))
+
+
+class ZfsVdevInferTypeTestCase(ZfsPluginTest):
+    """Tests for bd_zfs_vdev_infer_type() path-based type inference."""
+
+    # ---- keyword vdev types ----
+
+    @tag_test(TestTags.NOSTORAGE)
+    def test_mirror_prefix(self):
+        """mirror- prefix must return MIRROR"""
+        self.assertEqual(BlockDev.zfs_vdev_infer_type("mirror-0"),
+                         BlockDev.ZFSVdevType.MIRROR)
+
+    @tag_test(TestTags.NOSTORAGE)
+    def test_raidz1_prefix(self):
+        """raidz1- prefix must return RAIDZ1"""
+        self.assertEqual(BlockDev.zfs_vdev_infer_type("raidz1-0"),
+                         BlockDev.ZFSVdevType.RAIDZ1)
+
+    @tag_test(TestTags.NOSTORAGE)
+    def test_raidz_prefix(self):
+        """raidz- (no digit) prefix must return RAIDZ1"""
+        self.assertEqual(BlockDev.zfs_vdev_infer_type("raidz-0"),
+                         BlockDev.ZFSVdevType.RAIDZ1)
+
+    @tag_test(TestTags.NOSTORAGE)
+    def test_raidz2_prefix(self):
+        """raidz2- prefix must return RAIDZ2"""
+        self.assertEqual(BlockDev.zfs_vdev_infer_type("raidz2-0"),
+                         BlockDev.ZFSVdevType.RAIDZ2)
+
+    @tag_test(TestTags.NOSTORAGE)
+    def test_raidz3_prefix(self):
+        """raidz3- prefix must return RAIDZ3"""
+        self.assertEqual(BlockDev.zfs_vdev_infer_type("raidz3-0"),
+                         BlockDev.ZFSVdevType.RAIDZ3)
+
+    @tag_test(TestTags.NOSTORAGE)
+    def test_draid_prefix(self):
+        """draid prefix must return DRAID"""
+        self.assertEqual(BlockDev.zfs_vdev_infer_type("draid1:2d:4c:0s-0"),
+                         BlockDev.ZFSVdevType.DRAID)
+
+    @tag_test(TestTags.NOSTORAGE)
+    def test_spare_keyword(self):
+        """'spare' must return SPARE"""
+        self.assertEqual(BlockDev.zfs_vdev_infer_type("spare"),
+                         BlockDev.ZFSVdevType.SPARE)
+
+    @tag_test(TestTags.NOSTORAGE)
+    def test_spares_keyword(self):
+        """'spares' must return SPARE"""
+        self.assertEqual(BlockDev.zfs_vdev_infer_type("spares"),
+                         BlockDev.ZFSVdevType.SPARE)
+
+    @tag_test(TestTags.NOSTORAGE)
+    def test_log_keyword(self):
+        """'log' must return LOG"""
+        self.assertEqual(BlockDev.zfs_vdev_infer_type("log"),
+                         BlockDev.ZFSVdevType.LOG)
+
+    @tag_test(TestTags.NOSTORAGE)
+    def test_logs_keyword(self):
+        """'logs' must return LOG"""
+        self.assertEqual(BlockDev.zfs_vdev_infer_type("logs"),
+                         BlockDev.ZFSVdevType.LOG)
+
+    @tag_test(TestTags.NOSTORAGE)
+    def test_cache_keyword(self):
+        """'cache' must return CACHE"""
+        self.assertEqual(BlockDev.zfs_vdev_infer_type("cache"),
+                         BlockDev.ZFSVdevType.CACHE)
+
+    @tag_test(TestTags.NOSTORAGE)
+    def test_special_keyword(self):
+        """'special' must return SPECIAL"""
+        self.assertEqual(BlockDev.zfs_vdev_infer_type("special"),
+                         BlockDev.ZFSVdevType.SPECIAL)
+
+    @tag_test(TestTags.NOSTORAGE)
+    def test_dedup_keyword(self):
+        """'dedup' must return DEDUP"""
+        self.assertEqual(BlockDev.zfs_vdev_infer_type("dedup"),
+                         BlockDev.ZFSVdevType.DEDUP)
+
+    # ---- short device names (assumed DISK) ----
+
+    @tag_test(TestTags.NOSTORAGE)
+    def test_sd_device(self):
+        """'sda' must return DISK"""
+        self.assertEqual(BlockDev.zfs_vdev_infer_type("sda"),
+                         BlockDev.ZFSVdevType.DISK)
+
+    @tag_test(TestTags.NOSTORAGE)
+    def test_nvme_device(self):
+        """'nvme0n1' must return DISK"""
+        self.assertEqual(BlockDev.zfs_vdev_infer_type("nvme0n1"),
+                         BlockDev.ZFSVdevType.DISK)
+
+    @tag_test(TestTags.NOSTORAGE)
+    def test_vd_device(self):
+        """'vda' must return DISK"""
+        self.assertEqual(BlockDev.zfs_vdev_infer_type("vda"),
+                         BlockDev.ZFSVdevType.DISK)
+
+    # ---- absolute paths: stat()-based inference ----
+
+    @tag_test(TestTags.NOSTORAGE)
+    def test_regular_file_returns_file_type(self):
+        """An absolute path to a regular file must return FILE"""
+        with tempfile.NamedTemporaryFile() as tmp:
+            self.assertEqual(BlockDev.zfs_vdev_infer_type(tmp.name),
+                             BlockDev.ZFSVdevType.FILE)
+
+    @tag_test(TestTags.NOSTORAGE)
+    def test_nonexistent_path_returns_unknown(self):
+        """An absolute path that does not exist must return UNKNOWN"""
+        self.assertEqual(BlockDev.zfs_vdev_infer_type("/nonexistent/path/to/vdev"),
+                         BlockDev.ZFSVdevType.UNKNOWN)
+
+    @tag_test(TestTags.NOSTORAGE)
+    def test_directory_path_returns_unknown(self):
+        """An absolute path to a directory must return UNKNOWN (not DISK or FILE)"""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            self.assertEqual(BlockDev.zfs_vdev_infer_type(tmpdir),
+                             BlockDev.ZFSVdevType.UNKNOWN)
+
+    # ---- unrecognized name ----
+
+    @tag_test(TestTags.NOSTORAGE)
+    def test_unknown_name(self):
+        """An unrecognized name must return UNKNOWN"""
+        self.assertEqual(BlockDev.zfs_vdev_infer_type("foobar"),
+                         BlockDev.ZFSVdevType.UNKNOWN)


### PR DESCRIPTION
## Summary
- Use `stat()` for absolute paths: S_ISBLK→DISK, S_ISREG→FILE, else UNKNOWN
- Made function public as `bd_zfs_vdev_infer_type()` with GObject introspection binding
- 20 new tests covering keywords, device names, and stat-based classification

Closes #67

🤖 Generated with [Claude Code](https://claude.com/claude-code)