### PR TITLE
Fix packaging: add ZFS to %check, mirror [zfs] in test config fixtures

### DIFF
--- a/dist/libblockdev.spec.in
+++ b/dist/libblockdev.spec.in
@@ -687,6 +687,12 @@ autoreconf -ivf
 find %{buildroot} -type f -name "*.la" | xargs %{__rm}
 
 
+%check
+%if %{with_zfs}
+python3 tests/run_tests.py --include-tags nostorage zfs_test
+%endif
+
+
 %ldconfig_scriptlets
 %ldconfig_scriptlets utils
 

--- a/tests/test_configs/plugin_multi_conf.d/00-default.cfg
+++ b/tests/test_configs/plugin_multi_conf.d/00-default.cfg
@@ -41,3 +41,6 @@ sonames=libbd_swap.so.3
 
 [s390]
 sonames=libbd_s390.so.3
+
+[zfs]
+sonames=libbd_zfs.so.3

--- a/tests/test_configs/plugin_prio_conf.d/00-default.cfg
+++ b/tests/test_configs/plugin_prio_conf.d/00-default.cfg
@@ -41,3 +41,6 @@ sonames=libbd_swap.so.3
 
 [s390]
 sonames=libbd_s390.so.3
+
+[zfs]
+sonames=libbd_zfs.so.3


### PR DESCRIPTION
## Summary
- Add `[zfs]` section to both test config fixtures (multi + prio)
- Add conditional `%check` in spec running NOSTORAGE ZFS tests during RPM build
- Gated on `%{with_zfs}`

Closes #71

🤖 Generated with [Claude Code](https://claude.com/claude-code)