### PR TITLE
Fix FS info pool name validation + clone bare-name normalization

### DIFF
--- a/src/plugins/fs/zfs.c
+++ b/src/plugins/fs/zfs.c
@@ -175,6 +175,17 @@ resolve_pool_name_from_device (const gchar *device, GError **error) {
         return NULL;
     }
 
+    /* Validate the extracted pool name using the same canonical rules as
+     * bd_fs_zfs_check_label().  A corrupted or adversarial on-disk label
+     * could carry a crafted pool name that injects CLI options. */
+    if (!bd_fs_zfs_check_label (pool_name, error)) {
+        g_prefix_error (error,
+                        "Pool name from device '%s' failed validation: ",
+                        device);
+        g_free (pool_name);
+        return NULL;
+    }
+
     return pool_name;
 }
 
@@ -322,7 +333,7 @@ BDFSZfsInfo* bd_fs_zfs_get_info (const gchar *device, GError **error) {
         return NULL;
 
     /* Query the specific pool */
-    const gchar *argv[] = {"zpool", "list", "-H", "-p", "-o", "name,guid,size,free", pool_name, NULL};
+    const gchar *argv[] = {"zpool", "list", "-H", "-p", "-o", "name,guid,size,free", "--", pool_name, NULL};
     success = bd_utils_exec_and_capture_output (argv, NULL, &output, error);
     if (!success) {
         g_free (output);

--- a/src/plugins/zfs.c
+++ b/src/plugins/zfs.c
@@ -3345,6 +3345,7 @@ gboolean bd_zfs_snapshot_clone (const gchar *snapshot, const gchar *clone_name,
     guint next_arg = 0;
     gboolean success = FALSE;
     const BDExtraArg **extra_p = NULL;
+    gchar *effective_clone = NULL;
 
     if (!validate_name_not_option (snapshot, "Snapshot name", error))
         return FALSE;
@@ -3354,6 +3355,29 @@ gboolean bd_zfs_snapshot_clone (const gchar *snapshot, const gchar *clone_name,
 
     if (!check_deps (&avail_deps, DEPS_ZFS_MASK, deps, DEPS_LAST, &deps_check_lock, error))
         return FALSE;
+
+    /* Bare-name normalization: if clone_name contains no '/', prepend the
+     * pool name extracted from the snapshot name (everything before the
+     * first '/').  This matches the documented behaviour in the API spec. */
+    if (strchr (clone_name, '/') == NULL) {
+        const gchar *slash = strchr (snapshot, '/');
+        if (slash) {
+            gchar *pool = g_strndup (snapshot, slash - snapshot);
+            effective_clone = g_strdup_printf ("%s/%s", pool, clone_name);
+            g_free (pool);
+        } else {
+            /* snapshot is pool-level (pool@snap) — use pool prefix directly */
+            const gchar *at = strchr (snapshot, '@');
+            if (at) {
+                gchar *pool = g_strndup (snapshot, at - snapshot);
+                effective_clone = g_strdup_printf ("%s/%s", pool, clone_name);
+                g_free (pool);
+            } else {
+                /* Malformed snapshot name — fall through and let zfs(8) reject it */
+                effective_clone = g_strdup (clone_name);
+            }
+        }
+    }
 
     if (extra) {
         for (extra_p = extra; *extra_p; extra_p++) {
@@ -3380,11 +3404,12 @@ gboolean bd_zfs_snapshot_clone (const gchar *snapshot, const gchar *clone_name,
     }
     argv[next_arg++] = "--";
     argv[next_arg++] = snapshot;
-    argv[next_arg++] = clone_name;
+    argv[next_arg++] = effective_clone ? effective_clone : clone_name;
     argv[next_arg] = NULL;
 
     success = bd_utils_exec_and_report_error (argv, NULL, error);
     g_free (argv);
+    g_free (effective_clone);
     return success;
 }
 

--- a/tests/fs_tests/zfs_test.py
+++ b/tests/fs_tests/zfs_test.py
@@ -303,6 +303,43 @@ class ZfsTestCheckLabel(ZfsNoDevTestCase):
             BlockDev.fs_zfs_check_label(name)
 
 
+class ZfsTestCheckLabelPoolNameInjection(ZfsNoDevTestCase):
+    """Tests that bd_fs_zfs_check_label() catches names that a malicious
+    on-disk ZFS label could carry.  resolve_pool_name_from_device() now
+    validates the extracted pool name through check_label before passing
+    it to zpool(8)."""
+
+    @tag_test(TestTags.NOSTORAGE)
+    def test_rejects_option_injection(self):
+        """A pool name starting with '--' must be rejected"""
+        with self.assertRaisesRegex(GLib.GError, "must begin with a letter"):
+            BlockDev.fs_zfs_check_label("--help")
+
+    @tag_test(TestTags.NOSTORAGE)
+    def test_rejects_dash_o(self):
+        """A pool name like '-o' must be rejected"""
+        with self.assertRaisesRegex(GLib.GError, "must begin with a letter"):
+            BlockDev.fs_zfs_check_label("-o")
+
+    @tag_test(TestTags.NOSTORAGE)
+    def test_rejects_newline(self):
+        """A pool name containing a newline must be rejected"""
+        with self.assertRaisesRegex(GLib.GError, "contains invalid character"):
+            BlockDev.fs_zfs_check_label("pool\nname")
+
+    @tag_test(TestTags.NOSTORAGE)
+    def test_rejects_semicolon(self):
+        """A pool name containing ';' (shell metachar) must be rejected"""
+        with self.assertRaisesRegex(GLib.GError, "contains invalid character"):
+            BlockDev.fs_zfs_check_label("pool;rm")
+
+    @tag_test(TestTags.NOSTORAGE)
+    def test_rejects_backtick(self):
+        """A pool name containing backtick (command substitution) must be rejected"""
+        with self.assertRaisesRegex(GLib.GError, "contains invalid character"):
+            BlockDev.fs_zfs_check_label("pool`id`")
+
+
 class ZfsTestGetInfoNoFallback(ZfsNoDevTestCase):
 
     def test_get_info_fails_on_nonexistent_device(self):

--- a/tests/zfs_test.py
+++ b/tests/zfs_test.py
@@ -1072,6 +1072,55 @@ class ZfsExtraArgInsertionTestCase(ZfsPluginTest):
         self.assertNotIn("-- testpool/ds@snap1 testpool/clone1 -o", cmd)
 
     @tag_test(TestTags.NOSTORAGE)
+    def test_snapshot_clone_bare_name_normalized(self):
+        """snapshot_clone must prepend pool name when clone_name has no '/'"""
+        self._skip_unless_zfs_tools()
+        try:
+            BlockDev.zfs_snapshot_clone("testpool/ds@snap1", "myclone", None)
+        except GLib.GError:
+            pass
+        cmd = self._get_running_cmd()
+        self.assertIsNotNone(cmd)
+        self.assertIn("-- testpool/ds@snap1 testpool/myclone", cmd)
+
+    @tag_test(TestTags.NOSTORAGE)
+    def test_snapshot_clone_bare_name_pool_level_snapshot(self):
+        """snapshot_clone must prepend pool name from pool-level snapshot (pool@snap)"""
+        self._skip_unless_zfs_tools()
+        try:
+            BlockDev.zfs_snapshot_clone("testpool@snap1", "myclone", None)
+        except GLib.GError:
+            pass
+        cmd = self._get_running_cmd()
+        self.assertIsNotNone(cmd)
+        self.assertIn("-- testpool@snap1 testpool/myclone", cmd)
+
+    @tag_test(TestTags.NOSTORAGE)
+    def test_snapshot_clone_qualified_name_unchanged(self):
+        """snapshot_clone must not modify clone_name that already contains '/'"""
+        self._skip_unless_zfs_tools()
+        try:
+            BlockDev.zfs_snapshot_clone("testpool/ds@snap1", "otherpool/myclone", None)
+        except GLib.GError:
+            pass
+        cmd = self._get_running_cmd()
+        self.assertIsNotNone(cmd)
+        self.assertIn("-- testpool/ds@snap1 otherpool/myclone", cmd)
+
+    @tag_test(TestTags.NOSTORAGE)
+    def test_snapshot_clone_bare_name_with_extras(self):
+        """snapshot_clone must normalize bare name and still place extras before '--'"""
+        self._skip_unless_zfs_tools()
+        ea = BlockDev.ExtraArg.new("-o", "mountpoint=/mnt/clone")
+        try:
+            BlockDev.zfs_snapshot_clone("testpool/ds@snap1", "myclone", [ea])
+        except GLib.GError:
+            pass
+        cmd = self._get_running_cmd()
+        self.assertIsNotNone(cmd)
+        self.assertIn("-o mountpoint=/mnt/clone -- testpool/ds@snap1 testpool/myclone", cmd)
+
+    @tag_test(TestTags.NOSTORAGE)
     def test_zvol_create_extras_before_separator(self):
         """zvol_create must place extras before '--' and positional args"""
         self._skip_unless_zfs_tools()


### PR DESCRIPTION
## Summary
- Validate pool name from zdb -l against canonical rules before use in zpool list
- Add -- before pool name positional arg in zpool list argv
- Implement documented clone_name bare-name normalization (prepend pool prefix)
- 9 new tests

Closes #73, closes #74

🤖 Generated with [Claude Code](https://claude.com/claude-code)